### PR TITLE
`MoveWindowAndEnsureVisibile()` now factors in DPI scaling

### DIFF
--- a/TrackOMatic/Data/UIUtils.cs
+++ b/TrackOMatic/Data/UIUtils.cs
@@ -34,7 +34,6 @@ namespace TrackOMatic
             double windowScaledWidth = window.Width * dpiScale;
             double windowScaledHeight = window.Height * dpiScale;
             window.Left = Math.Max(currentScreen.WorkingArea.Left, x) / dpiScale;
-            Console.WriteLine("mouse coords (" + x + ", " + y + ")");
             if (window.Left + window.Width > (currentScreen.WorkingArea.Left + currentScreen.WorkingArea.Width) / dpiScale)
             {
                 window.Left = (currentScreen.WorkingArea.Left + currentScreen.WorkingArea.Width - windowScaledWidth) / dpiScale;
@@ -44,8 +43,6 @@ namespace TrackOMatic
             {
                 window.Top = (currentScreen.WorkingArea.Top + currentScreen.WorkingArea.Height - windowScaledHeight) / dpiScale;
             }
-            Console.WriteLine("Window Pos: (" + window.Left + ", " + window.Top + ")");
-            Console.WriteLine("Window Size: (" + window.Width + ", " + window.Height + ")");
         }
     }
 }

--- a/TrackOMatic/Data/UIUtils.cs
+++ b/TrackOMatic/Data/UIUtils.cs
@@ -1,26 +1,51 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
+using System.Drawing;
 using System.Windows;
-using System.Windows.Controls;
+using System.Windows.Forms;
 
 namespace TrackOMatic
 {
     static class UIUtils
     {
+        public static float GetDpiScale()
+        {
+            Form form = new Form();
+            Graphics g = form.CreateGraphics();
+            float defaultDpi = 96.0f;
+            float dpi = defaultDpi; // default DPI is 96
+
+            try
+            {
+                dpi = g.DpiX;
+            }
+            finally
+            {
+                g.Dispose();
+            }
+
+            form.Dispose();
+            return dpi / defaultDpi;
+        }
 
         public static void MoveWindowAndEnsureVisibile(Window window, double x, double y)
         {
+            float dpiScale = GetDpiScale();
             var currentScreen = System.Windows.Forms.Screen.FromPoint(System.Windows.Forms.Cursor.Position);
-            window.Left = Math.Max(currentScreen.WorkingArea.Left, x);
-            if (window.Left + window.Width > currentScreen.WorkingArea.Left + currentScreen.WorkingArea.Width)
+            double windowScaledWidth = window.Width * dpiScale;
+            double windowScaledHeight = window.Height * dpiScale;
+            window.Left = Math.Max(currentScreen.WorkingArea.Left, x) / dpiScale;
+            Console.WriteLine("mouse coords (" + x + ", " + y + ")");
+            if (window.Left + window.Width > (currentScreen.WorkingArea.Left + currentScreen.WorkingArea.Width) / dpiScale)
             {
-                window.Left = currentScreen.WorkingArea.Left + currentScreen.WorkingArea.Width - window.Width;
+                window.Left = (currentScreen.WorkingArea.Left + currentScreen.WorkingArea.Width - windowScaledWidth) / dpiScale;
             }
-            window.Top = Math.Max(currentScreen.WorkingArea.Top, y);
-            if (window.Top + window.Height > currentScreen.WorkingArea.Top + currentScreen.WorkingArea.Height)
+            window.Top = Math.Max(currentScreen.WorkingArea.Top, y) / dpiScale;
+            if (window.Top + window.Height > (currentScreen.WorkingArea.Top + currentScreen.WorkingArea.Height) / dpiScale)
             {
-                window.Top = currentScreen.WorkingArea.Top + currentScreen.WorkingArea.Height - window.Height;
+                window.Top = (currentScreen.WorkingArea.Top + currentScreen.WorkingArea.Height - windowScaledHeight) / dpiScale;
             }
+            Console.WriteLine("Window Pos: (" + window.Left + ", " + window.Top + ")");
+            Console.WriteLine("Window Size: (" + window.Width + ", " + window.Height + ")");
         }
     }
 }


### PR DESCRIPTION
Fix for #2 

Summary of changes:

* Added new UI utils function to get current DPI scale ratio (compared to the default 96 DPI)
* `MoveWindowAndEnsureVisibile()` now accounts for DPI scale when determining whether the dialog needs to be moved to be within the display bounds.