### PR TITLE
Enable Auto-Build and Release of latest committed version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Windows Executable
-          path: '**/bin/Release/*'
+          path: ./dist/windows
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: Linux-Binaries
-          path: '**/bin/linux-x64/*'
+          path: ./dist/linux
   release:
     needs: [build-windows, build-linux]
     if: always()  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.3
@@ -56,16 +54,27 @@ jobs:
           name: Linux-Binaries
           path: '**/bin/linux-x64/*'
   release:
-    needs: build-windows
+    needs: [build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download Windows built
+        uses: actions/download-artifact@v4
         with:
           name: Windows Executable
-          path: ./dist
+          path: ./dist/windows
+      - name: Download Linux built
+        uses: actions/download-artifact@v4
+        with:
+          name: Linux Executable
+          path: ./dist/linux
       - name: Generate tag
         run: |
           VERSION="v$(date +'%Y.%m.%d.%H%M')"   # e.g. v2025.11.06.2019
+          echo "TAG=$VERSION" >> $GITHUB_ENV
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git tag $VERSION
@@ -75,7 +84,9 @@ jobs:
       - name: Create Github Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name }}
-          files: './dist/Release/*'
+          tag_name: ${{ env.TAG }}
+          files: |
+            './dist/windows/*'
+            './dist/linux/*'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           tag_name: ${{ env.TAG }}
           files: |
-            dist/windows/**
-            dist/linux/**
+            dist/windows/windows.zip
+            dist/linux/linux.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,11 @@
-name: Build Visual Studio Project
+name: Build Visual Studio Project & Release
 
 on:
   push:
     branches:
       - build
+    tags:
+      - 'auto'
   workflow_dispatch:
 
 env:
@@ -33,8 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Windows Executable
-          path: |
-            **/bin/Release/*
+          path: '**/bin/Release/*'
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +44,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '4.8'
+          dotnet-version: '6.0'
       - name: Restore packages
         run: dotnet restore ${{ env.SOLUTION_FILE }}
       - name: Build solution
@@ -51,4 +52,18 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: Linux-Binaries
-          path: '**/bin/${{ env.CONFIGURATION }}/net*/linux-x64/*'
+          path: '**/bin/linux-x64/*'
+  release:
+    needs: build-windows
+    run-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+        name: Windows Executable
+        path: ./dist
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: './dist/Release/*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
           git tag $VERSION
           git push origin $VERSION
           ls
+          ls dist/windows
+          ls dist/linux
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,17 @@ jobs:
         with:
           name: Windows Executable
           path: ./dist
+      - name: Generate tag
+        run: |
+          VERSION="v$(date +'%Y.%m.%d.%H%M')"   # e.g. v2025.11.06.2019
+          git tag $VERSION
+          git push origin $VERSION
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.ref_name }}
           files: './dist/Release/*'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,6 @@ jobs:
           git config user.email "github-actions@github.com"
           git tag $VERSION
           git push origin $VERSION
-          git tag $VERSION
-          git push origin $VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.3
@@ -48,7 +50,7 @@ jobs:
       - name: Restore packages
         run: dotnet restore ${{ env.SOLUTION_FILE }}
       - name: Build solution
-        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --runtime linux-x64
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration release --runtime linux-x64
       - uses: actions/upload-artifact@v4
         with:
           name: Linux-Binaries
@@ -64,6 +66,10 @@ jobs:
       - name: Generate tag
         run: |
           VERSION="v$(date +'%Y.%m.%d.%H%M')"   # e.g. v2025.11.06.2019
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag $VERSION
+          git push origin $VERSION
           git tag $VERSION
           git push origin $VERSION
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
           git config user.email "github-actions@github.com"
           git tag $VERSION
           git push origin $VERSION
+          ls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,6 @@ jobs:
           git push origin $VERSION
           ls
           ls dist/windows
-          ls dist/linux
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release
@@ -97,7 +96,7 @@ jobs:
         with:
           tag_name: ${{ env.TAG }}
           files: |
-            './dist/windows/**'
-            './dist/linux/**'
+            dist/windows/**
+            dist/linux/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ jobs:
         run: nuget restore ${{ env.SOLUTION_FILE }}
 
       - name: Build solution
-        run: msbuild ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:Platform="Any CPU" /p:OutDir=dist/windows/
+        run: msbuild ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:Platform="Any CPU" /p:OutDir=${{ github.workspace }}\dist\windows\
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Windows Executable
-          path: dist/windows
+          path: dist/windows/**
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -48,11 +48,11 @@ jobs:
       - name: Restore packages
         run: dotnet restore ${{ env.SOLUTION_FILE }}
       - name: Build solution
-        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration Release --runtime linux-x64 --output dist/linux/
+        run: dotnet publish ${{ env.SOLUTION_FILE }} --configuration Release --runtime linux-x64 --output dist/linux/
       - uses: actions/upload-artifact@v4
         with:
           name: Linux Executable
-          path: dist/linux
+          path: dist/linux/**
   release:
     needs: [build-windows, build-linux]
     if: always()  
@@ -94,7 +94,7 @@ jobs:
         with:
           tag_name: ${{ env.TAG }}
           files: |
-            './dist/windows/*'
-            './dist/linux/*'
+            './dist/windows/**'
+            './dist/linux/**'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           tag_name: ${{ env.TAG }}
           files: |
-            dist/windows/windows.zip
-            dist/linux/linux.tar.gz
+            windows.zip
+            linux.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,16 @@ jobs:
           git config user.email "github-actions@github.com"
           git tag $VERSION
           git push origin $VERSION
-          ls
-          ls dist/windows
+          if [ -d "dist/windows" ] && [ "$(ls -A dist/windows)" ]; then
+            zip -r windows.zip dist/windows || true
+          else
+            echo "No Windows executable found."
+          fi
+          if [ -d "dist/linux" ] && [ "$(ls -A dist/linux)" ]; then
+            tar -czf linux.tar.gz dist/linux || true
+          else
+            echo "No Linux binary found.
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           if [ -d "dist/linux" ] && [ "$(ls -A dist/linux)" ]; then
             tar -czf linux.tar.gz dist/linux || true
           else
-            echo "No Linux binary found.
+            echo "No Linux binary found."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Windows Executable
+          name: 'Windows Executable'
           path: ./dist/windows
   build-linux:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
         run: dotnet build ${{ env.SOLUTION_FILE }} --configuration release --runtime linux-x64
       - uses: actions/upload-artifact@v4
         with:
-          name: Linux-Binaries
+          name: 'Linux Executable'
           path: ./dist/linux
   release:
     needs: [build-windows, build-linux]
@@ -66,14 +66,14 @@ jobs:
         id: windows_built
         uses: actions/download-artifact@v4
         with:
-          name: Windows Executable
+          name: 'Windows Executable'
           path: ./dist/windows
         continue-on-error: true
       - name: Download Linux built
         id: linux_built
         uses: actions/download-artifact@v4
         with:
-          name: Linux Executable
+          name: 'Linux Executable'
           path: ./dist/linux
         continue-on-error: true
       - name: Generate tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
         run: nuget restore ${{ env.SOLUTION_FILE }}
 
       - name: Build solution
-        run: msbuild ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:Platform="Any CPU" /p:OutDir=dist/windows/
 
-      - name: Upload build artifacts
+      - name: Upload build artifactsthe
         uses: actions/upload-artifact@v4
         with:
           name: 'Windows Executable'
@@ -48,7 +48,7 @@ jobs:
       - name: Restore packages
         run: dotnet restore ${{ env.SOLUTION_FILE }}
       - name: Build solution
-        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration release --runtime linux-x64
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration Release --runtime linux-x64 --output dist/linux/
       - uses: actions/upload-artifact@v4
         with:
           name: 'Linux Executable'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
           path: '**/bin/linux-x64/*'
   release:
     needs: [build-windows, build-linux]
+    if: always()  
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -62,15 +63,19 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download Windows built
+        id: windows_built
         uses: actions/download-artifact@v4
         with:
           name: Windows Executable
           path: ./dist/windows
+        continue-on-error: true
       - name: Download Linux built
+        id: linux_built
         uses: actions/download-artifact@v4
         with:
           name: Linux Executable
           path: ./dist/linux
+        continue-on-error: true
       - name: Generate tag
         run: |
           VERSION="v$(date +'%Y.%m.%d.%H%M')"   # e.g. v2025.11.06.2019
@@ -82,6 +87,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release
+        if: |
+          (steps.windows_built.outcome == 'success') || 
+          (steps.linux_built.outcome == 'success')
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Build solution
         run: msbuild ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:Platform="Any CPU" /p:OutDir=dist/windows/
 
-      - name: Upload build artifactsthe
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: 'Windows Executable'
-          path: ./dist/windows
+          name: Windows Executable
+          path: dist/windows
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -51,8 +51,8 @@ jobs:
         run: dotnet build ${{ env.SOLUTION_FILE }} --configuration Release --runtime linux-x64 --output dist/linux/
       - uses: actions/upload-artifact@v4
         with:
-          name: 'Linux Executable'
-          path: ./dist/linux
+          name: Linux Executable
+          path: dist/linux
   release:
     needs: [build-windows, build-linux]
     if: always()  
@@ -66,15 +66,15 @@ jobs:
         id: windows_built
         uses: actions/download-artifact@v4
         with:
-          name: 'Windows Executable'
-          path: ./dist/windows
+          name: Windows Executable
+          path: dist/windows
         continue-on-error: true
       - name: Download Linux built
         id: linux_built
         uses: actions/download-artifact@v4
         with:
-          name: 'Linux Executable'
-          path: ./dist/linux
+          name: Linux Executable
+          path: dist/linux
         continue-on-error: true
       - name: Generate tag
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Visual Studio Project
+
+on:
+  push:
+    branches:
+      - build
+  workflow_dispatch:
+
+env:
+  SOLUTION_FILE: Track-O-Matic.sln
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.3
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.2.0
+
+      - name: Restore packages
+        run: nuget restore ${{ env.SOLUTION_FILE }}
+
+      - name: Build solution
+        run: msbuild ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:Platform="Any CPU"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Executable
+          path: |
+            **/bin/Release/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,12 @@ jobs:
           path: '**/bin/linux-x64/*'
   release:
     needs: build-windows
-    run-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
-        name: Windows Executable
-        path: ./dist
+          name: Windows Executable
+          path: ./dist
       - name: Create Github Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
   SOLUTION_FILE: Track-O-Matic.sln
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
 
     steps:
@@ -32,6 +32,23 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Executable
+          name: Windows Executable
           path: |
             **/bin/Release/*
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '4.8'
+      - name: Restore packages
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+      - name: Build solution
+        run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --runtime linux-x64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Linux-Binaries
+          path: '**/bin/${{ env.CONFIGURATION }}/net*/linux-x64/*'

--- a/Track-O-Matic.sln
+++ b/Track-O-Matic.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32901.215
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Track-O-Matic", "Track-O-Matic\Track-O-Matic.csproj", "{91260922-9FBA-4508-9593-430514E34A2B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Track-O-Matic", "TrackOMatic\Track-O-Matic.csproj", "{91260922-9FBA-4508-9593-430514E34A2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Track-O-Matic.sln
+++ b/Track-O-Matic.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32901.215
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Track-O-Matic", "DK64PointsTracker\Track-O-Matic.csproj", "{91260922-9FBA-4508-9593-430514E34A2B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Track-O-Matic", "Track-O-Matic\Track-O-Matic.csproj", "{91260922-9FBA-4508-9593-430514E34A2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
I went through the effort to add a Github Workflow action to automate building the source code in `build` branch and pushing a release with the latest commit tag.

I don't encourage pulling this right into main yet, rather first cloning this into another branch to check if you can replicate this process without much trouble. Maybe make the Release job optional and only upload a working built artifact that you can review, then create a release off that if it's proven functional.

Aside from adding the workflow file, I had to make one change to `Track-O-Matic.sln` to have this work. I don't know if on your local machine you have the `.csproj` file inside a directory called `DK64PointsTracker`, but that directory doesn't exist on this repository; you have to use `TrackOMatic` instead, be consistent with the repository.

There are 2 other important notes about this process:

1. The tag generated to be attached to the release is based on compile time, not version numbering. This pull needs changes to have it attach version numbers like the main setup by:
  - `TrackOMatic/AutoUpdateInfo.xml`, change the version number on lines 3 and 4
  - `TrackOMatic/MainWindow.xaml`, change the version number on line 80
  - `TrackOMatic/MainWindow.xaml.cs`, change the version number on line 600
  
Then, the $VERSION variable in the workflow can take that number and attach the proper tag to it.

2. I made a separate job to attempt to build on Linux, but this will always fail because this project depends on .net 4.8, which is not compatible with Linux builds. The project needs to be refactored to use at least dotnet 6.0, which is a big feat outside the scope of this PR. This job can be made optional or separate for now.

A functional native Linux port would be good for DK64R speedrunners or racers that must use a Linux machine. While you *could* technically run both the Windows executables of the emulator with the game and this tool inside a Wine prefix, it's not proven if the tool can read the emulator while inside Wine, nevermind work properly. But again, outside the scope of this PR.