### PR TITLE
Update NuGet packages to latest stable for 4.8.

### DIFF
--- a/TrackOMatic/Track-O-Matic.csproj
+++ b/TrackOMatic/Track-O-Matic.csproj
@@ -345,7 +345,7 @@
       <Version>1.8.4</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
-      <Version>5.1.0</Version>
+      <Version>5.7.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -353,22 +353,23 @@
       <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.1" />
-    <PackageReference Include="Fody">
-      <Version>6.1.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Humanizer.Core">
       <Version>2.14.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
+      <Version>13.0.4</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
+      <Version>4.5.5</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>5.0.2</Version>
+      <Version>8.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions">
+      <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
The following were updated for stability and vulnerability reasons:

* Newtonsoft.Json to 13.0.4
* System.Memory to 4.5.5
* System.Text.RegularExpressiosn to 4.3.1
* System.Net.Http to 4.3.4
* Costura.Fody to 5.7.0
* Fody is no longer required as a separate install

There are later versions of Costura.Fody but they require changing the structure of the csproj file. Let's not introduce those changes in this PR.