### PR TITLE
Add missing Japes Shared Shops to shortcuts.

### DIFF
--- a/TrackOMatic/default_shortcuts.json
+++ b/TrackOMatic/default_shortcuts.json
@@ -214,11 +214,13 @@
     "jjfulk": "Japes Funky Lanky",
     "jjfutk": "Japes Funky Tiny",
     "jjfuck": "Japes Funky Chunky",
+    "jjfush": "Japes Funky Shared",
     "jjcrdk": "Japes Cranky Donkey",
     "jjcrdi": "Japes Cranky Diddy",
     "jjcrlk": "Japes Cranky Lanky",
     "jjcrtk": "Japes Cranky Tiny",
     "jjcrck": "Japes Cranky Chunky",
+    "jjcrsh": "Japes Cranky Shared",
 
     "jjdkme": "Japes Donkey Medal",
     "jjfree": "Japes Hillside Item",


### PR DESCRIPTION
Don't want to mislead newer players on this tracker.