### PR TITLE
Remove unneeded packages.config file.

### DIFF
--- a/TrackOMatic/packages.config
+++ b/TrackOMatic/packages.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-</packages>


### PR DESCRIPTION
Since moving to the SDK format, PackageReference listings in the csproj itself now contains the maintained list of items. As such, this relic should be removed for consistency.