### PR TITLE
Have all using statments sorted/cleaned.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ trim_trailing_whitespace = true
 [*.cs]
 indent_style = space
 indent_size = 4
+dotnet_sort_system_directives_first = true
 
 # New lines
 csharp_new_line_before_open_brace = all

--- a/TrackOMatic/AutoTracking/AttachToEmulator.cs
+++ b/TrackOMatic/AutoTracking/AttachToEmulator.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Windows;
 using System.Management;
 
 namespace TrackOMatic

--- a/TrackOMatic/AutoTracking/Autotracker.cs
+++ b/TrackOMatic/AutoTracking/Autotracker.cs
@@ -1,15 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Windows;
-using Newtonsoft.Json;
-using System.IO;
-using System.Windows.Documents;
-using System.Windows.Media.Animation;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Timers;
+using System.Windows;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/AutoTracking/EmulatorName.cs
+++ b/TrackOMatic/AutoTracking/EmulatorName.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TrackOMatic
 {
     public enum EmulatorName

--- a/TrackOMatic/AutoTracking/Memory.cs
+++ b/TrackOMatic/AutoTracking/Memory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 

--- a/TrackOMatic/AutoTracking/OffsetInfo.cs
+++ b/TrackOMatic/AutoTracking/OffsetInfo.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Windows.Documents;
-
 namespace TrackOMatic
 {
     public static class OffsetInfo

--- a/TrackOMatic/BasicItemSelector.xaml.cs
+++ b/TrackOMatic/BasicItemSelector.xaml.cs
@@ -1,18 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/BroadcastView.xaml.cs
+++ b/TrackOMatic/BroadcastView.xaml.cs
@@ -1,20 +1,8 @@
-using System;
-using System.CodeDom;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using TrackOMatic;
+
 using TrackOMatic.Properties;
 
 namespace TrackOMatic

--- a/TrackOMatic/CollectibleItem.xaml.cs
+++ b/TrackOMatic/CollectibleItem.xaml.cs
@@ -1,10 +1,10 @@
-using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+
 using TrackOMatic.Properties;
 
 namespace TrackOMatic

--- a/TrackOMatic/Data/BarrierItems.cs
+++ b/TrackOMatic/Data/BarrierItems.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TrackOMatic.Data
 {
     public enum BarrierItems

--- a/TrackOMatic/Data/Bosses.cs
+++ b/TrackOMatic/Data/Bosses.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TrackOMatic.Data
 {
     public enum Bosses

--- a/TrackOMatic/Data/Extensions.cs
+++ b/TrackOMatic/Data/Extensions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace TrackOMatic
 {
     static class Extensions

--- a/TrackOMatic/Data/HintData.cs
+++ b/TrackOMatic/Data/HintData.cs
@@ -1,14 +1,8 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
+
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/Data/HintHelper.cs
+++ b/TrackOMatic/Data/HintHelper.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace TrackOMatic
 {
     public static class HintHelper

--- a/TrackOMatic/Data/HintRegion.cs
+++ b/TrackOMatic/Data/HintRegion.cs
@@ -1,10 +1,3 @@
-using System.CodeDom;
-using System.Collections.Generic;
-using System;
-using System.Globalization;
-using Newtonsoft.Json;
-using System.IO;
-
 namespace TrackOMatic
 {
     public enum HintRegion

--- a/TrackOMatic/Data/HintTypeSettingsList.cs
+++ b/TrackOMatic/Data/HintTypeSettingsList.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Windows;
-using System.Windows.Controls.Primitives;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/Data/ImportantCheckList.cs
+++ b/TrackOMatic/Data/ImportantCheckList.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Windows.Controls.Primitives;
-
 namespace TrackOMatic
 {
     public static class ImportantCheckList

--- a/TrackOMatic/Data/JSONKeyMappings.cs
+++ b/TrackOMatic/Data/JSONKeyMappings.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Data;
 using TrackOMatic.Data;
 
 namespace TrackOMatic

--- a/TrackOMatic/Data/MapToRegion.cs
+++ b/TrackOMatic/Data/MapToRegion.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TrackOMatic
 {
     public class MapToRegion

--- a/TrackOMatic/Data/PointValues.cs
+++ b/TrackOMatic/Data/PointValues.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TrackOMatic
 {
     public class PointValues

--- a/TrackOMatic/Data/Records.cs
+++ b/TrackOMatic/Data/Records.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Collections.Generic;
 using System.Windows;
 
 namespace TrackOMatic

--- a/TrackOMatic/Data/Region.cs
+++ b/TrackOMatic/Data/Region.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Imaging;
-using System.Xml.Linq;
-using System.Windows;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/Data/SavedHint.cs
+++ b/TrackOMatic/Data/SavedHint.cs
@@ -1,7 +1,3 @@
-using System.Windows;
-using System.Windows.Documents;
-using System.Collections.Generic;
-
 namespace TrackOMatic
 {
     public class SavedHint

--- a/TrackOMatic/Data/SavedProgress.cs
+++ b/TrackOMatic/Data/SavedProgress.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace TrackOMatic
 {
     public class SavedProgress

--- a/TrackOMatic/Data/SongFormatting.cs
+++ b/TrackOMatic/Data/SongFormatting.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Humanizer;
 
 namespace TrackOMatic

--- a/TrackOMatic/Data/UIUtils.cs
+++ b/TrackOMatic/Data/UIUtils.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;

--- a/TrackOMatic/DataSaver.cs
+++ b/TrackOMatic/DataSaver.cs
@@ -1,14 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media.Imaging;
-using System.IO;
-using Microsoft.Win32;
-using System.Linq;
 using Newtonsoft.Json;
-using System.Timers;
-using System.Threading;
+
+using System.IO;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HintsUI/BLockerHint.xaml.cs
+++ b/TrackOMatic/HintsUI/BLockerHint.xaml.cs
@@ -1,19 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+
 using TrackOMatic.Data;
 
 namespace TrackOMatic

--- a/TrackOMatic/HintsUI/BLockerPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/BLockerPanel.xaml.cs
@@ -1,20 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using TrackOMatic.Data;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HintsUI/HelmDoorHint.xaml.cs
+++ b/TrackOMatic/HintsUI/HelmDoorHint.xaml.cs
@@ -1,19 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HintsUI/HelmDoorPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/HelmDoorPanel.xaml.cs
@@ -1,19 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HintsUI/HintInfo.xaml.cs
+++ b/TrackOMatic/HintsUI/HintInfo.xaml.cs
@@ -1,17 +1,8 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 

--- a/TrackOMatic/HintsUI/HintItemList.xaml.cs
+++ b/TrackOMatic/HintsUI/HintItemList.xaml.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;

--- a/TrackOMatic/HintsUI/HintItemSelectionDialog.xaml.cs
+++ b/TrackOMatic/HintsUI/HintItemSelectionDialog.xaml.cs
@@ -1,17 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HintsUI/HintPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/HintPanel.xaml.cs
@@ -1,13 +1,9 @@
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
+
 using TrackOMatic.Properties;
 
 namespace TrackOMatic

--- a/TrackOMatic/HintsUI/ItemCountBox.cs
+++ b/TrackOMatic/HintsUI/ItemCountBox.cs
@@ -1,13 +1,11 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 
 namespace TrackOMatic
 {
     public class ItemCountBox : TextBox
     {
-
 
         public ItemCountBox()
         {

--- a/TrackOMatic/HintsUI/PathOrFoundItem.xaml.cs
+++ b/TrackOMatic/HintsUI/PathOrFoundItem.xaml.cs
@@ -1,14 +1,8 @@
-using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HintsUI/SelectableHintItem.xaml.cs
+++ b/TrackOMatic/HintsUI/SelectableHintItem.xaml.cs
@@ -1,13 +1,9 @@
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Runtime.InteropServices;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System;
-using System.Windows.Media.Imaging;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/HitListHintManager.cs
+++ b/TrackOMatic/HitListHintManager.cs
@@ -1,13 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media.Imaging;
-using System.IO;
-using Microsoft.Win32;
-using System.Linq;
-using Newtonsoft.Json;
-using System.Timers;
 using TrackOMatic.Properties;
 
 namespace TrackOMatic

--- a/TrackOMatic/HitListItem.xaml.cs
+++ b/TrackOMatic/HitListItem.xaml.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace TrackOMatic

--- a/TrackOMatic/Item.xaml.cs
+++ b/TrackOMatic/Item.xaml.cs
@@ -1,7 +1,4 @@
-using System;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.IO.Ports;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -9,7 +6,6 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/ItemBackground.xaml.cs
+++ b/TrackOMatic/ItemBackground.xaml.cs
@@ -1,12 +1,9 @@
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Runtime.InteropServices;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/LevelOrderNumber.xaml.cs
+++ b/TrackOMatic/LevelOrderNumber.xaml.cs
@@ -1,10 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Security.Cryptography;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+
 using TrackOMatic.Properties;
 
 namespace TrackOMatic

--- a/TrackOMatic/MainWindow.xaml.cs
+++ b/TrackOMatic/MainWindow.xaml.cs
@@ -1,16 +1,18 @@
-using System;
-using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
-using System.IO;
-using Microsoft.Win32;
-using System.ComponentModel;
-using System.Linq;
-using System.Timers;
-using TrackOMatic.Properties;
+
 using AutoUpdaterDotNET;
+
+using Microsoft.Win32;
+
+using TrackOMatic.Properties;
+
+using Timer = System.Timers.Timer;
 
 namespace System.Runtime.CompilerServices
 {

--- a/TrackOMatic/ProgHintDialog.xaml.cs
+++ b/TrackOMatic/ProgHintDialog.xaml.cs
@@ -1,19 +1,6 @@
-using System;
-using System.CodeDom;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/ProgressiveItem.xaml.cs
+++ b/TrackOMatic/ProgressiveItem.xaml.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace TrackOMatic

--- a/TrackOMatic/RegionGrid.xaml.cs
+++ b/TrackOMatic/RegionGrid.xaml.cs
@@ -1,19 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Markup;
-using System.Windows.Media;
-using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/SpoilerParser.cs
+++ b/TrackOMatic/SpoilerParser.cs
@@ -1,18 +1,12 @@
-using Microsoft.Win32;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
+
 using System.IO;
-using System.Linq;
-using System.Runtime;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using TrackOMatic.Data;
+
 using TrackOMatic.Properties;
 
 namespace TrackOMatic

--- a/TrackOMatic/Toggles.cs
+++ b/TrackOMatic/Toggles.cs
@@ -1,14 +1,7 @@
-using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Media.Imaging;
-using System.Linq;
-using System.Windows.Data;
+
 using TrackOMatic.Properties;
-using System.ComponentModel;
-using System.Windows.Input;
-using System.Collections.Generic;
 
 namespace TrackOMatic
 {

--- a/TrackOMatic/Track-O-Matic.csproj
+++ b/TrackOMatic/Track-O-Matic.csproj
@@ -15,7 +15,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>12.0</LangVersion>
     <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
+    <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     


### PR DESCRIPTION
This is done by taking advantage of `<ImplicitUsings>` to reduce the number of using statements we need. Visual Studio's context menu to Remove and Sort Usings automatically removes what's not in use.

The editor config line was added to handle an edge case where System usings were not first when they should be.