### PR TITLE
Convert HintTypeSettings to boolean fields.

### DIFF
--- a/TrackOMatic/Converters/BooleanToVisibilityConverter.cs
+++ b/TrackOMatic/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace TrackOMatic.Converters;
+
+public class BooleanToVisibilityConverter : IValueConverter
+{
+    public Visibility FalseVisibility { get; set; } = Visibility.Collapsed;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool boolValue)
+        {
+            return boolValue ? Visibility.Visible : FalseVisibility;
+        }
+        return FalseVisibility;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Visibility visibility)
+        {
+            return visibility == Visibility.Visible;
+        }
+        return false;
+    }
+}

--- a/TrackOMatic/Data/HintTypeSettingsList.cs
+++ b/TrackOMatic/Data/HintTypeSettingsList.cs
@@ -5,16 +5,16 @@ namespace TrackOMatic
     public static class HintTypeSettingsList
     {
         public static readonly Dictionary<HintType, HintTypeSettings> SETTINGS = new(){
-            {HintType.PATH, new HintTypeSettings(Visibility.Visible, Visibility.Visible, HintSuggestion.LOCATION, false, Visibility.Collapsed, Visibility.Visible) },
-            {HintType.KONGS, new HintTypeSettings(Visibility.Hidden, Visibility.Visible, HintSuggestion.NONE, true) },
-            {HintType.WAY_OF_THE_HOARD, new HintTypeSettings(Visibility.Hidden, Visibility.Visible, HintSuggestion.CHECK) },
-            {HintType.REGION_POTION_COUNT, new HintTypeSettings(Visibility.Hidden, Visibility.Hidden, HintSuggestion.LOCATION, false, Visibility.Visible) },
-            {HintType.FOOLISH_REGION, new HintTypeSettings(Visibility.Hidden, Visibility.Hidden, HintSuggestion.LOCATION) },
-            {HintType.PATHLESS_MOVE, new HintTypeSettings(Visibility.Hidden, Visibility.Hidden, HintSuggestion.MOVE) },
-            {HintType.UNHINTED, new HintTypeSettings(Visibility.Hidden, Visibility.Visible, HintSuggestion.CHECK, true) },
-            {HintType.MISC, new HintTypeSettings(Visibility.Hidden, Visibility.Hidden, HintSuggestion.NONE) },
-            {HintType.DIRECT_ITEM_HINT, new HintTypeSettings(Visibility.Hidden, Visibility.Visible, HintSuggestion.DIRECT_ITEM_HINT, true, Visibility.Collapsed) },
-            {HintType.ADVANCED_ITEM_HINT, new HintTypeSettings(Visibility.Hidden, Visibility.Visible, HintSuggestion.LOCATION, false) }
+            {HintType.PATH, new HintTypeSettings(true, true, HintSuggestion.LOCATION, false, false, true) },
+            {HintType.KONGS, new HintTypeSettings(false, true, HintSuggestion.NONE, true) },
+            {HintType.WAY_OF_THE_HOARD, new HintTypeSettings(false, true, HintSuggestion.CHECK) },
+            {HintType.REGION_POTION_COUNT, new HintTypeSettings(false, false, HintSuggestion.LOCATION, false, true) },
+            {HintType.FOOLISH_REGION, new HintTypeSettings(false, false, HintSuggestion.LOCATION) },
+            {HintType.PATHLESS_MOVE, new HintTypeSettings(false, false, HintSuggestion.MOVE) },
+            {HintType.UNHINTED, new HintTypeSettings(false, true, HintSuggestion.CHECK, true) },
+            {HintType.MISC, new HintTypeSettings(false, false, HintSuggestion.NONE) },
+            {HintType.DIRECT_ITEM_HINT, new HintTypeSettings(false, true, HintSuggestion.DIRECT_ITEM_HINT, true, true) },
+            {HintType.ADVANCED_ITEM_HINT, new HintTypeSettings(false, true, HintSuggestion.LOCATION, false) }
        };
     }
 }

--- a/TrackOMatic/Data/Records.cs
+++ b/TrackOMatic/Data/Records.cs
@@ -7,12 +7,12 @@ namespace TrackOMatic
     public record AttachedProcessInfo(Process Process, ulong StartAddress);
     public record OffsetInfoEntry(ItemName ItemName, uint Offset, int TotalBits, int Bitmask = 0, bool UsesCountStruct = false);
     public record HintTypeSettings(
-        Visibility PathItemsVisible,
-        Visibility FoundItemVisible,
+        bool PathItemsVisible,
+        bool FoundItemVisible,
         HintSuggestion HintSuggestion,
         bool PromptForFoundItem = false,
-        Visibility PotionCountVisibility = Visibility.Collapsed,
-        Visibility HintSorterVisibility = Visibility.Collapsed);
+        bool PotionCountVisibility = false,
+        bool HintSorterVisibility = false);
     public record HintShortcutInfo(string JSONShortcutsKey, List<string> DefaultSortedList);
     public record BLockerInfo(int item, int cost);
 }

--- a/TrackOMatic/HintsUI/HintInfo.xaml
+++ b/TrackOMatic/HintsUI/HintInfo.xaml
@@ -1,12 +1,17 @@
-﻿<UserControl x:Name="HintInfoWindow" x:Class="TrackOMatic.HintInfo"
+<UserControl x:Name="HintInfoWindow" x:Class="TrackOMatic.HintInfo"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TrackOMatic"
-                xmlns:wpf="http://wpfcontrols.com/"
+             xmlns:converters="clr-namespace:TrackOMatic.Converters"
+             xmlns:wpf="http://wpfcontrols.com/"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="200">
+    <UserControl.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToHiddenVisibilityConverter" FalseVisibility="Hidden" />
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToCollapsedVisibilityConverter" FalseVisibility="Collapsed" />
+    </UserControl.Resources>
     <Border x:Name="border" Background="{StaticResource RegionBG}" CornerRadius="0" Padding="4,3,3,3" BorderBrush="Black" BorderThickness=".5">
         <Grid x:Name="yes"> 
             <Grid.RowDefinitions>
@@ -16,7 +21,7 @@
                         <Style TargetType="RowDefinition">
                             <Setter Property="Height" Value="*"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="Hidden">
+                                <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="false">
                                     <Setter Property="Height" Value="0" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -27,10 +32,10 @@
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="Hidden">
+                        <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="false">
                             <Setter Property="Height" Value="23"/>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="Visible">
+                        <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="true">
                             <Setter Property="Height" Value="46"/>
                         </DataTrigger>
                     </Style.Triggers>
@@ -41,10 +46,10 @@
                 <ColumnDefinition Width="2*"/>
             </Grid.ColumnDefinitions>
             <TextBox ContextMenu="{x:Null}" Margin="1,0,0,0" TextChanged="Location_TextChanged" PreviewMouseRightButtonDown="Location_PreviewMouseRightButtonDown"  PreviewKeyDown="Location_PreviewKeyDown" x:Name="Location" Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource BoldText}"/>
-            <TextBox ContextMenu="{x:Null}" x:Name="PotionCount" PreviewMouseRightButtonDown="Location_PreviewMouseRightButtonDown"  PreviewKeyDown="PotionCount_PreviewKeyDown" Margin="0,0,3,0"  Grid.Column="1" HorizontalContentAlignment="Right" Style="{StaticResource BoldText}" VerticalAlignment="Center" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PotionCountVisibility}"/>
+            <TextBox ContextMenu="{x:Null}" x:Name="PotionCount" PreviewMouseRightButtonDown="Location_PreviewMouseRightButtonDown"  PreviewKeyDown="PotionCount_PreviewKeyDown" Margin="0,0,3,0"  Grid.Column="1" HorizontalContentAlignment="Right" Style="{StaticResource BoldText}" VerticalAlignment="Center" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PotionCountVisibility, Converter={StaticResource BooleanToCollapsedVisibilityConverter}}"/>
 
-            <local:HintItemList Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" x:Name="RightItems" BottomRowHeight="*" CustomHorizontalAlignment="Right" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.FoundItemVisible}"/>
-            <local:HintItemList Margin="1,0,0,0" Loaded="HintInfoWindow_Loaded" x:Name="ItemsOnPath" Grid.Row="1" BottomRowHeight="0" CustomHorizontalAlignment="Left" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}"/>
+            <local:HintItemList Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" x:Name="RightItems" BottomRowHeight="*" CustomHorizontalAlignment="Right" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.FoundItemVisible, Converter={StaticResource BooleanToHiddenVisibilityConverter}}"/>
+            <local:HintItemList Margin="1,0,0,0" Loaded="HintInfoWindow_Loaded" x:Name="ItemsOnPath" Grid.Row="1" BottomRowHeight="0" CustomHorizontalAlignment="Left" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible, Converter={StaticResource BooleanToHiddenVisibilityConverter}}"/>
             <Popup Grid.Row="1" x:Name="BottomRow" Height="120" Width="250" Placement="Bottom" PlacementTarget="{Binding ElementName=Location}">
             <ListBox MouseDoubleClick="SuggestionBox_MouseDoubleClick" Margin="0,0,0,0" FontFamily="Roboto" FontSize="14" Foreground="White" Background="{StaticResource RegionImageBG}" x:Name="SuggestionBox"  KeyDown="SuggestionBox_KeyDown"/>
             </Popup>

--- a/TrackOMatic/HintsUI/HintInfo.xaml.cs
+++ b/TrackOMatic/HintsUI/HintInfo.xaml.cs
@@ -56,7 +56,7 @@ namespace TrackOMatic
             SavedHint = new SavedHint(panelName, Location.Text, PotionCount.Text, new(), new());
             ItemsOnPath.HintInfo = this;
             RightItems.HintInfo = this;
-            if (HintTypeSettings.PathItemsVisible != Visibility.Visible)
+            if (!HintTypeSettings.PathItemsVisible)
             {
                 RightItems.BottomRow.Height = new GridLength(0);
             }
@@ -224,7 +224,7 @@ namespace TrackOMatic
             }
             BottomRow.IsOpen = false;
 
-            if (HintTypeSettings.PathItemsVisible == Visibility.Visible && !UserInitialized)
+            if (HintTypeSettings.PathItemsVisible && !UserInitialized)
             {
                 ItemsOnPath.OpenItemSelectionDialog();
                 UserInitialized = true;

--- a/TrackOMatic/HintsUI/HintPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/HintPanel.xaml.cs
@@ -46,8 +46,8 @@ namespace TrackOMatic
         public void OnLoaded(object sender, RoutedEventArgs e)
         {
             var hintSettings = HintTypeSettingsList.SETTINGS[HintType];
-            SortButton.Visibility = hintSettings.HintSorterVisibility;
-            FilterButton.Visibility = hintSettings.HintSorterVisibility;
+            SortButton.Visibility = hintSettings.HintSorterVisibility ? Visibility.Visible : Visibility.Collapsed;
+            FilterButton.Visibility = hintSettings.HintSorterVisibility ? Visibility.Visible : Visibility.Collapsed;
         }
         public HintPanel()
         {


### PR DESCRIPTION
In moving to allow Linux natively, we cannot rely on using `System.Windows.Visibility`. Fortunately, every `Visibility` in use was only using two values, so a `BooleanToVisibilityConverter` with a flexible `FalseVisibility` property was used to maintain the old behavior.

I personally believe an additional `null` check in `HintInfo.xaml.cs` would be safer, but it's technically not required at this stage. The errors from the previous pull request were due to passing in `Collapsed` instead of `Hidden` inside.