### PR TITLE
Replace Visibility with UI agnostic version.

### DIFF
--- a/TrackOMatic/Data/Extensions.cs
+++ b/TrackOMatic/Data/Extensions.cs
@@ -17,5 +17,27 @@ namespace TrackOMatic
                 list[n] = value;
             }
         }
+
+        public static ItemVisibilityState ToItemVisibility(this System.Windows.Visibility visibility)
+        {
+            return visibility switch
+            {
+                System.Windows.Visibility.Visible => ItemVisibilityState.Visible,
+                System.Windows.Visibility.Hidden => ItemVisibilityState.Hidden,
+                System.Windows.Visibility.Collapsed => ItemVisibilityState.Collapsed,
+                _ => throw new ArgumentOutOfRangeException(nameof(visibility), visibility, null)
+            };
+        }
+
+        public static System.Windows.Visibility ToWpfVisibility(this ItemVisibilityState visibility)
+        {
+            return visibility switch
+            {
+                ItemVisibilityState.Visible => System.Windows.Visibility.Visible,
+                ItemVisibilityState.Hidden => System.Windows.Visibility.Hidden,
+                ItemVisibilityState.Collapsed => System.Windows.Visibility.Collapsed,
+                _ => throw new ArgumentOutOfRangeException(nameof(visibility), visibility, null)
+            };
+        }
     }
 }

--- a/TrackOMatic/Data/ItemVisibilityState.cs
+++ b/TrackOMatic/Data/ItemVisibilityState.cs
@@ -1,0 +1,8 @@
+namespace TrackOMatic;
+
+public enum ItemVisibilityState
+{
+    Visible,
+    Hidden,
+    Collapsed,
+}

--- a/TrackOMatic/Data/SavedItem.cs
+++ b/TrackOMatic/Data/SavedItem.cs
@@ -1,16 +1,14 @@
-using System.Windows;
-
 namespace TrackOMatic
 {
     public class SavedItem
     {
         public ItemName ItemName { get; }
         public RegionName Region { get; }
-        public Visibility Starred { get; }
+        public ItemVisibilityState Starred { get; }
         public bool Autotracked { get; set; }
         public double Opacity { get; }
         public bool Hinted { get; }
-        public SavedItem(ItemName itemName, RegionName region, Visibility starred, bool autotracked, double opacity, bool hinted = false)
+        public SavedItem(ItemName itemName, RegionName region, ItemVisibilityState starred, bool autotracked, double opacity, bool hinted = false)
         {
             ItemName = itemName;
             Region = region;

--- a/TrackOMatic/DataSaver.cs
+++ b/TrackOMatic/DataSaver.cs
@@ -104,7 +104,7 @@ namespace TrackOMatic
                 {
                     continue;
                 }
-                matchingItem.SetStarVisibility(savedItem.Starred);
+                matchingItem.SetStarVisibility(savedItem.Starred.ToWpfVisibility());
                 matchingItem.ChangeOpacity(savedItem.Opacity);
                 if (savedItem.Autotracked)
                 {

--- a/TrackOMatic/Item.xaml.cs
+++ b/TrackOMatic/Item.xaml.cs
@@ -205,7 +205,7 @@ namespace TrackOMatic
             var itemName = (ItemName)Tag;
             var regionName = (Region == null) ? RegionName.UNKNOWN : Region.RegionName;
             bool autotracked = mainWindow.Autotracker.ItemWasTracked(itemName);
-            mainWindow.DataSaver.AddSavedItem(new SavedItem(itemName, regionName, Star.Visibility, autotracked, Image.Opacity));
+            mainWindow.DataSaver.AddSavedItem(new SavedItem(itemName, regionName, Star.Visibility.ToItemVisibility(), autotracked, Image.Opacity));
         }
 
         //Struct to use in the GetCursorPos function

--- a/TrackOMatic/MainWindow.xaml.cs
+++ b/TrackOMatic/MainWindow.xaml.cs
@@ -286,7 +286,7 @@ namespace TrackOMatic
                 BroadcastView.TurnItemOn(itemToProcess);
             }
 
-            DataSaver.AddSavedItem(new SavedItem(itemToProcess, regionName, item.Star.Visibility, true, item.Image.Opacity));
+            DataSaver.AddSavedItem(new SavedItem(itemToProcess, regionName, item.Star.Visibility.ToItemVisibility(), true, item.Image.Opacity));
             DataSaver.Save("autosave.json", canAutosave);
             return true;
         }


### PR DESCRIPTION
Linux cannot use WPF namespaces. To maintain save file compatibility, introduce our own enum with matching values.

It may be better to have the Starred attribute be a boolean instead, but I'm not making that change unless authorized.