### PR TITLE
Stop leaking exceptions for autotracking failure.

### DIFF
--- a/TrackOMatic/AutoTracking/AttachToEmulator.cs
+++ b/TrackOMatic/AutoTracking/AttachToEmulator.cs
@@ -7,16 +7,15 @@ namespace TrackOMatic
     {
         private static Process? FindProcess(string name)
         {
-            Process target;
             try
             {
-                target = Process.GetProcessesByName(name)[0];
+                var processes = Process.GetProcessesByName(name);
+                return processes?.FirstOrDefault();
             }
             catch (Exception)
             {
                 return null;
             }
-            return target;
         }
         private static AttachedProcessInfo? AttachToProject64(Process target, GameVerificationInfo verificationInfo)
         {


### PR DESCRIPTION
If no processes are running that we can attach to, that's known behavior, not exceptional. No need to have that be caught in the catch block and clog up the Debug output.