### PR TITLE
Consistent usage/pathing of FindResource images.

### DIFF
--- a/TrackOMatic/BaseBarrelPadImages.xaml
+++ b/TrackOMatic/BaseBarrelPadImages.xaml
@@ -1,27 +1,27 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:TrackOMatic">
 
-    <BitmapImage x:Key="strong_kong" UriSource="Images\dk64\dkbarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="rocketbarrel_boost" UriSource="Images\dk64\diddybarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="orangstand_sprint" UriSource="Images\dk64\lankybarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="mini_monkey" UriSource="Images\dk64\tinybarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="hunky_chunky" UriSource="Images\dk64\chunkybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="strong_kong" UriSource="Images/dk64/dkbarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rocketbarrel_boost" UriSource="Images/dk64/diddybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="orangstand_sprint" UriSource="Images/dk64/lankybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="mini_monkey" UriSource="Images/dk64/tinybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="hunky_chunky" UriSource="Images/dk64/chunkybarrel.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="baboon_blast" UriSource="Images\dk64\dkpad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="simian_spring" UriSource="Images\dk64\diddypad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="monkeyport" UriSource="Images\dk64\tinypad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone" UriSource="Images\dk64\chunkypad.png" />
+    <BitmapImage x:Key="baboon_blast" UriSource="Images/dk64/dkpad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="simian_spring" UriSource="Images/dk64/diddypad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="monkeyport" UriSource="Images/dk64/tinypad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad.png" />
 
     <!--Black&White-->
-    <BitmapImage x:Key="strong_kong_bw" UriSource="Images\bw\dkbarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images\bw\diddybarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images\bw\lankybarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images\bw\tinybarrel.png"  x:Shared="false"/>
-    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images\bw\chunkybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="strong_kong_bw" UriSource="Images/bw/dkbarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images/bw/diddybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images/bw/lankybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images/bw/tinybarrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images/bw/chunkybarrel.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images\bw\dkpad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="simian_spring_bw" UriSource="Images\bw\diddypad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="monkeyport_bw" UriSource="Images\bw\tinypad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images\bw\chunkypad.png" />
+    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images/bw/dkpad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="simian_spring_bw" UriSource="Images/bw/diddypad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="monkeyport_bw" UriSource="Images/bw/tinypad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad.png" />
 </ResourceDictionary>

--- a/TrackOMatic/BaseBarrelPadImages.xaml
+++ b/TrackOMatic/BaseBarrelPadImages.xaml
@@ -11,7 +11,7 @@
     <BitmapImage x:Key="baboon_blast" UriSource="Images/dk64/dkpad.png"  x:Shared="false"/>
     <BitmapImage x:Key="simian_spring" UriSource="Images/dk64/diddypad.png"  x:Shared="false"/>
     <BitmapImage x:Key="monkeyport" UriSource="Images/dk64/tinypad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad.png" />
+    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad.png" x:Shared="false"/>
 
     <!--Black&White-->
     <BitmapImage x:Key="strong_kong_bw" UriSource="Images/bw/dkbarrel.png"  x:Shared="false"/>
@@ -23,5 +23,5 @@
     <BitmapImage x:Key="baboon_blast_bw" UriSource="Images/bw/dkpad.png"  x:Shared="false"/>
     <BitmapImage x:Key="simian_spring_bw" UriSource="Images/bw/diddypad.png"  x:Shared="false"/>
     <BitmapImage x:Key="monkeyport_bw" UriSource="Images/bw/tinypad.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad.png" />
+    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad.png" x:Shared="false"/>
 </ResourceDictionary>

--- a/TrackOMatic/BroadcastView.xaml
+++ b/TrackOMatic/BroadcastView.xaml
@@ -1,4 +1,4 @@
-﻿<Window Closed="Window_Closed" x:Class="TrackOMatic.BroadcastView"
+<Window Closed="Window_Closed" x:Class="TrackOMatic.BroadcastView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -139,11 +139,11 @@
                     <local:ItemBackground Margin="1" Interactible="False" x:Name="chunky_pad"  BackgroundItemImage="{DynamicResource gorilla_gone_bw}" Grid.Row="4" Grid.Column="5" Panel.ZIndex="0" Tag="{x:Static local:ItemName.GORILLA_GONE}"/>
 
                     <!--Blueprints-->
-                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="DonkeyBPs" ImageSource="Images\bw\dk_bp.png" Text="0" Grid.Row="0" Grid.Column="6" />
-                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="DiddyBPs" ImageSource="Images\bw\diddy_bp.png" Text="0" Grid.Row="1" Grid.Column="6"/>
-                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="LankyBPs" ImageSource="Images\bw\lanky_bp.png" Text="0" Grid.Row="2" Grid.Column="6"/>
-                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="TinyBPs" ImageSource="Images\bw\tiny_bp.png" Text="0" Grid.Row="3" Grid.Column="6"/>
-                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="ChunkyBPs" ImageSource="Images\bw\chunky_bp.png" Text="0" Grid.Row="4" Grid.Column="6"/>
+                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="DonkeyBPs" ImageSource="Images/bw/dk_bp.png" Text="0" Grid.Row="0" Grid.Column="6" />
+                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="DiddyBPs" ImageSource="Images/bw/diddy_bp.png" Text="0" Grid.Row="1" Grid.Column="6"/>
+                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="LankyBPs" ImageSource="Images/bw/lanky_bp.png" Text="0" Grid.Row="2" Grid.Column="6"/>
+                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="TinyBPs" ImageSource="Images/bw/tiny_bp.png" Text="0" Grid.Row="3" Grid.Column="6"/>
+                    <local:CollectibleItem Margin="1" RowHeight=".9*" BGColor="Black" Interactible="False" x:Name="ChunkyBPs" ImageSource="Images/bw/chunky_bp.png" Text="0" Grid.Row="4" Grid.Column="6"/>
                 </Grid>
                 <Grid Name="TrainingMovesGrid" Grid.Row="2" Margin="2">
                     <Grid.ColumnDefinitions>
@@ -319,7 +319,7 @@
                     <ColumnDefinition Width="1*"/>
                     <ColumnDefinition Width=".5*"/>
                 </Grid.ColumnDefinitions>
-                <Image x:Name="HelmLabel" Source="Images\dk64\lanky_bp.png" Grid.Column="1" Margin="0"/>
+                <Image x:Name="HelmLabel" Source="Images/dk64/lanky_bp.png" Grid.Column="1" Margin="0"/>
                 <local:ProgressiveItem  x:Name="HelmKong1"  Opacity="1" Grid.Column="3" Margin="0" />
                 <local:ProgressiveItem x:Name="HelmKong2" Opacity="1"  Grid.Column="4" Margin="0" />
                 <local:ProgressiveItem  x:Name="HelmKong3"  Opacity="1" Grid.Column="5" Margin="0" />
@@ -338,7 +338,7 @@
                     <ColumnDefinition Width="1*"/>
                     <ColumnDefinition Width=".5*"/>
                 </Grid.ColumnDefinitions>
-                <Image x:Name="KRoolLabel" Source="Images\dk64\krool.png" Grid.Column="1" Margin="0,0,0,0"/>
+                <Image x:Name="KRoolLabel" Source="Images/dk64/krool.png" Grid.Column="1" Margin="0,0,0,0"/>
                 <local:ProgressiveItem  x:Name="KRoolKong1"  Opacity="1" Grid.Column="3" Margin="0" />
                 <local:ProgressiveItem x:Name="KRoolKong2" Opacity="1"  Grid.Column="4" Margin="0" />
                 <local:ProgressiveItem  x:Name="KRoolKong3"  Opacity="1" Grid.Column="5" Margin="0" />
@@ -357,12 +357,12 @@
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
             <local:ItemBackground Margin="1" Interactible="False" x:Name="bean"  BackgroundItemImage="{DynamicResource bean_bw}" Grid.Column="0" Panel.ZIndex="0" Tag="{x:Static local:ItemName.BEAN}"/>
-            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="pearls" ImageSource="Images\bw\pearl.png" Text="0" Grid.Row="0" Grid.Column="1"/>
-            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="battle_crowns" ImageSource="Images\bw\crown.png" Text="0" Grid.Row="0" Grid.Column="2"/>
-            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="banana_medals" ImageSource="Images\bw\bananamedal.png" Text="0" Grid.Row="0" Grid.Column="3"/>
-            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="rainbow_coins" ImageSource="Images\bw\rainbowcoin.png" Text="0" Grid.Row="0" Grid.Column="4"/>
-            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="banana_fairies" ImageSource="Images\bw\fairy.png" Text="0" Grid.Row="0" Grid.Column="5"/>
-            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="golden_bananas" ImageSource="Images\bw\gb.png" Text="0" Grid.Row="0" Grid.Column="6"/>
+            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="pearls" ImageSource="Images/bw/pearl.png" Text="0" Grid.Row="0" Grid.Column="1"/>
+            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="battle_crowns" ImageSource="Images/bw/crown.png" Text="0" Grid.Row="0" Grid.Column="2"/>
+            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="banana_medals" ImageSource="Images/bw/bananamedal.png" Text="0" Grid.Row="0" Grid.Column="3"/>
+            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="rainbow_coins" ImageSource="Images/bw/rainbowcoin.png" Text="0" Grid.Row="0" Grid.Column="4"/>
+            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="banana_fairies" ImageSource="Images/bw/fairy.png" Text="0" Grid.Row="0" Grid.Column="5"/>
+            <local:CollectibleItem BGColor="Black" Interactible="False" x:Name="golden_bananas" ImageSource="Images/bw/gb.png" Text="0" Grid.Row="0" Grid.Column="6"/>
         </Grid>
         <Grid Background="Transparent" Grid.Row="4" Margin="3,1,3,5" >
             <Border Grid.Row="0" Grid.RowSpan="3" CornerRadius="5" BorderThickness="1" BorderBrush="#131414" Background="#1a1b1c">
@@ -373,7 +373,7 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Grid Grid.Column="0" Margin="3,0,0,0">
-                    <Image x:Name="Headphones" Margin="3" Grid.Row="1" Source="Images\dk64\headphones.png" Grid.Column="0"  Panel.ZIndex="2" Opacity="1" HorizontalAlignment="Center"/>
+                    <Image x:Name="Headphones" Margin="3" Grid.Row="1" Source="Images/dk64/headphones.png" Grid.Column="0"  Panel.ZIndex="2" Opacity="1" HorizontalAlignment="Center"/>
                 </Grid>
                 <Grid Grid.Column="1" Margin="6,0,0,0" >
                     <Grid.RowDefinitions>

--- a/TrackOMatic/BroadcastView.xaml.cs
+++ b/TrackOMatic/BroadcastView.xaml.cs
@@ -59,29 +59,20 @@ namespace TrackOMatic
             {RegionName.HIDEOUT_HELM, -1 }
         };
 
-        private List<BitmapImage> homingScopeImages = new()
-        {
-                new BitmapImage( new Uri("images/bw/homingscope.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/homingonly.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/scopeonly.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/homingscope.png", UriKind.Relative)),
-        };
+        private List<string> homingScopeImages =
+        [
+            "homing_scope_bw", "homingonly", "scopeonly", "homing_scope"
+        ];
 
-        private List<BitmapImage> camShockwaveImages = new()
-        {
-                new BitmapImage( new Uri("images/bw/filmwave.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/fairycamonly.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/shockwaveonly.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/filmwave.png", UriKind.Relative)),
-        };
+        private List<string> camShockwaveImages =
+        [
+            "camera_shockwave_bw", "fairycamonly", "shockwaveonly", "camera_shockwave"
+        ];
 
-        private List<BitmapImage> slamImages = new()
-        {
-                new BitmapImage( new Uri("images/bw/progressive_slam.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/progressive_slam.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/slam2.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/slam3.png", UriKind.Relative)),
-        };
+        private List<string> slamImages =
+        [
+            "progressive_slam_1_bc_bw", "progressive_slam_1_bc", "progressive_slam_2_bc", "progressive_slam_3_bc"
+        ];
 
         private List<Image> LevelNames;
         private List<TextBlock> PointLabels;
@@ -220,7 +211,7 @@ namespace TrackOMatic
         {
             foreach (var image in LevelNames)
             {
-                image.Source = new BitmapImage(new Uri("Images/dk64/unknown.png", UriKind.Relative));
+                image.Source = (ImageSource)FindResource("unknown_label");
             }
             for (int i = 0; i < PointLabels.Count - 1; ++i) //skip isles
             {
@@ -314,8 +305,8 @@ namespace TrackOMatic
                 }
 
                 var matchingImage = LevelNames[levelNumber];
-                var imagePath = "Images/dk64/" + region.ToString().ToLower() + "_label.png";
-                matchingImage.Source = new BitmapImage(new Uri(imagePath, UriKind.Relative));
+                var imagePath = region.ToString().ToLower() + "_label";
+                matchingImage.Source = (ImageSource)FindResource(imagePath);
                 var mainWindow = (MainWindow)Application.Current.MainWindow;
                 if (mainWindow.Regions.ContainsKey(region))
                 {
@@ -390,7 +381,7 @@ namespace TrackOMatic
             }
         }
 
-        private void CheckGroupedItem(List<ItemName> items, List<BitmapImage> imageSources, ItemBackground itemBackground)
+        private void CheckGroupedItem(List<ItemName> items, IList<string> imageSources, ItemBackground itemBackground)
         {
             int imageIndex = 0;
             ItemName firstItem = items[0];
@@ -405,7 +396,7 @@ namespace TrackOMatic
                 imageIndex += 2;
             }
 
-            itemBackground.BackgroundItemImage = imageSources[imageIndex];
+            itemBackground.BackgroundItemImage = (ImageSource)FindResource(imageSources[imageIndex]);
         }
 
         public void HandleSharedMoves()
@@ -418,7 +409,7 @@ namespace TrackOMatic
                     slamCount++;
                 }
             }
-            slam.BackgroundItemImage = slamImages[slamCount];
+            slam.BackgroundItemImage = (ImageSource)FindResource(slamImages[slamCount]);
             var homingScopeGroup = new List<ItemName> { ItemName.HOMING_AMMO, ItemName.SNIPER_SCOPE };
             var camShockwaveGroup = new List<ItemName> { ItemName.FAIRY_CAMERA, ItemName.SHOCKWAVE };
             CheckGroupedItem(homingScopeGroup, homingScopeImages, homingscope);

--- a/TrackOMatic/ColoredBarrelPadImages.xaml
+++ b/TrackOMatic/ColoredBarrelPadImages.xaml
@@ -1,27 +1,27 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:TrackOMatic">
 
-    <BitmapImage x:Key="strong_kong" UriSource="Images\dk64\dkbarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="rocketbarrel_boost" UriSource="Images\dk64\diddybarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="orangstand_sprint" UriSource="Images\dk64\lankybarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="mini_monkey" UriSource="Images\dk64\tinybarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="hunky_chunky" UriSource="Images\dk64\chunkybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="strong_kong" UriSource="Images/dk64/dkbarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rocketbarrel_boost" UriSource="Images/dk64/diddybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="orangstand_sprint" UriSource="Images/dk64/lankybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="mini_monkey" UriSource="Images/dk64/tinybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="hunky_chunky" UriSource="Images/dk64/chunkybarrel_c.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="baboon_blast" UriSource="Images\dk64\dkpad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="simian_spring" UriSource="Images\dk64\diddypad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="monkeyport" UriSource="Images\dk64\tinypad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone" UriSource="Images\dk64\chunkypad_c.png" />
+    <BitmapImage x:Key="baboon_blast" UriSource="Images/dk64/dkpad_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="simian_spring" UriSource="Images/dk64/diddypad_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="monkeyport" UriSource="Images/dk64/tinypad_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad_c.png" />
 
     <!--Black&White-->
-    <BitmapImage x:Key="strong_kong_bw" UriSource="Images\bw\dkbarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images\bw\diddybarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images\bw\lankybarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images\bw\tinybarrel_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images\bw\chunkybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="strong_kong_bw" UriSource="Images/bw/dkbarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images/bw/diddybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images/bw/lankybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images/bw/tinybarrel_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images/bw/chunkybarrel_c.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images\bw\dkpad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="simian_spring_bw" UriSource="Images\bw\diddypad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="monkeyport_bw" UriSource="Images\bw\tinypad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images\bw\chunkypad_c.png" />
+    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images/bw/dkpad_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="simian_spring_bw" UriSource="Images/bw/diddypad_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="monkeyport_bw" UriSource="Images/bw/tinypad_c.png"  x:Shared="false"/>
+    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad_c.png" />
 </ResourceDictionary>

--- a/TrackOMatic/ColoredBarrelPadImages.xaml
+++ b/TrackOMatic/ColoredBarrelPadImages.xaml
@@ -11,7 +11,7 @@
     <BitmapImage x:Key="baboon_blast" UriSource="Images/dk64/dkpad_c.png"  x:Shared="false"/>
     <BitmapImage x:Key="simian_spring" UriSource="Images/dk64/diddypad_c.png"  x:Shared="false"/>
     <BitmapImage x:Key="monkeyport" UriSource="Images/dk64/tinypad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad_c.png" />
+    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad_c.png" x:Shared="false"/>
 
     <!--Black&White-->
     <BitmapImage x:Key="strong_kong_bw" UriSource="Images/bw/dkbarrel_c.png"  x:Shared="false"/>
@@ -23,5 +23,5 @@
     <BitmapImage x:Key="baboon_blast_bw" UriSource="Images/bw/dkpad_c.png"  x:Shared="false"/>
     <BitmapImage x:Key="simian_spring_bw" UriSource="Images/bw/diddypad_c.png"  x:Shared="false"/>
     <BitmapImage x:Key="monkeyport_bw" UriSource="Images/bw/tinypad_c.png"  x:Shared="false"/>
-    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad_c.png" />
+    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad_c.png" x:Shared="false"/>
 </ResourceDictionary>

--- a/TrackOMatic/Dictionary1.xaml
+++ b/TrackOMatic/Dictionary1.xaml
@@ -24,215 +24,280 @@
     <!-- question mark for unknown item-->
     <BitmapImage x:Key="none" UriSource="Images/dk64/none.png" x:Shared="false" />
 
-    <BitmapImage x:Key="locked_region" UriSource="Images\dk64\locked_region.png" x:Shared="false" />
-    <BitmapImage x:Key="star_simple" UriSource="Images\dk64\star_simple.png" x:Shared="false" />
-    <BitmapImage x:Key="star_complex" UriSource="Images\dk64\star_complex.png" x:Shared="false" />
-    <BitmapImage x:Key="x" UriSource="Images\dk64\x.png" x:Shared="false" />
+    <BitmapImage x:Key="locked_region" UriSource="Images/dk64/locked_region.png" x:Shared="false" />
+    <BitmapImage x:Key="star_simple" UriSource="Images/dk64/star_simple.png" x:Shared="false" />
+    <BitmapImage x:Key="star_complex" UriSource="Images/dk64/star_complex.png" x:Shared="false" />
+    <BitmapImage x:Key="x" UriSource="Images/dk64/x.png" x:Shared="false" />
 
-    <BitmapImage x:Key="unknown_kong" UriSource="Images\dk64\unknown_kong.png" x:Shared="false" />
-    <BitmapImage x:Key="dk_isles" UriSource="Images\dk64\dk_isles.png" x:Shared="false" />
-    <BitmapImage x:Key="start" UriSource="Images\dk64\start.png" x:Shared="false" />
+    <BitmapImage x:Key="unknown_kong" UriSource="Images/dk64/unknown_kong.png" x:Shared="false" />
+    <BitmapImage x:Key="dk_isles" UriSource="Images/dk64/dk_isles.png" x:Shared="false" />
+    <BitmapImage x:Key="start" UriSource="Images/dk64/start.png" x:Shared="false" />
     
-    <BitmapImage x:Key="jungle_japes" UriSource="Images\dk64\jungle_japes.png" x:Shared="false" />
-    <BitmapImage x:Key="angry_aztec" UriSource="Images\dk64\angry_aztec.png" x:Shared="false" />
-    <BitmapImage x:Key="frantic_factory" UriSource="Images\dk64\frantic_factory.png" x:Shared="false" />
-    <BitmapImage x:Key="gloomy_galleon" UriSource="Images\dk64\gloomy_galleon.png" x:Shared="false" />
-    <BitmapImage x:Key="fungi_forest" UriSource="Images\dk64\fungi_forest.png" x:Shared="false" />
-    <BitmapImage x:Key="crystal_caves" UriSource="Images\dk64\crystal_caves.png" x:Shared="false" />
-    <BitmapImage x:Key="creepy_castle" UriSource="Images\dk64\creepy_castle.png" x:Shared="false" />
-    <BitmapImage x:Key="hideout_helm" UriSource="Images\dk64\hideout_helm.png" x:Shared="false" />
+    <BitmapImage x:Key="jungle_japes" UriSource="Images/dk64/jungle_japes.png" x:Shared="false" />
+    <BitmapImage x:Key="angry_aztec" UriSource="Images/dk64/angry_aztec.png" x:Shared="false" />
+    <BitmapImage x:Key="frantic_factory" UriSource="Images/dk64/frantic_factory.png" x:Shared="false" />
+    <BitmapImage x:Key="gloomy_galleon" UriSource="Images/dk64/gloomy_galleon.png" x:Shared="false" />
+    <BitmapImage x:Key="fungi_forest" UriSource="Images/dk64/fungi_forest.png" x:Shared="false" />
+    <BitmapImage x:Key="crystal_caves" UriSource="Images/dk64/crystal_caves.png" x:Shared="false" />
+    <BitmapImage x:Key="creepy_castle" UriSource="Images/dk64/creepy_castle.png" x:Shared="false" />
+    <BitmapImage x:Key="hideout_helm" UriSource="Images/dk64/hideout_helm.png" x:Shared="false" />
 
-    <BitmapImage x:Key="donkey_krool" UriSource="Images\dk64\krool-donkey.png"  x:Shared="false"/>
-    <BitmapImage x:Key="diddy_krool" UriSource="Images\dk64\krool-diddy.png"  x:Shared="false"/>
-    <BitmapImage x:Key="lanky_krool" UriSource="Images\dk64\krool-lanky.png"  x:Shared="false" />
-    <BitmapImage x:Key="tiny_krool" UriSource="Images\dk64\krool-tiny.png"  x:Shared="false" />
-    <BitmapImage x:Key="chunky_krool" UriSource="Images\dk64\krool-chunky.png"  x:Shared="false" />
+    <BitmapImage x:Key="jungle_japes_label" UriSource="Images/dk64/jungle_japes_label.png" x:Shared="false" />
+    <BitmapImage x:Key="angry_aztec_label" UriSource="Images/dk64/angry_aztec_label.png" x:Shared="false" />
+    <BitmapImage x:Key="frantic_factory_label" UriSource="Images/dk64/frantic_factory_label.png" x:Shared="false" />
+    <BitmapImage x:Key="gloomy_galleon_label" UriSource="Images/dk64/gloomy_galleon_label.png" x:Shared="false" />
+    <BitmapImage x:Key="fungi_forest_label" UriSource="Images/dk64/fungi_forest_label.png" x:Shared="false" />
+    <BitmapImage x:Key="crystal_caves_label" UriSource="Images/dk64/crystal_caves_label.png" x:Shared="false" />
+    <BitmapImage x:Key="creepy_castle_label" UriSource="Images/dk64/creepy_castle_label.png" x:Shared="false" />
+    <BitmapImage x:Key="hideout_helm_label" UriSource="Images/dk64/hideout_helm_label.png" x:Shared="false" />
+    <BitmapImage x:Key="dk_isles_label" UriSource="Images/dk64/isles.png" x:Shared="false" />
+    <BitmapImage x:Key="unknown_label" UriSource="Images/dk64/unknown.png" x:Shared="false" />
 
-    <BitmapImage x:Key="donkey" UriSource="Images\dk64\donkey.png"  x:Shared="false"/>
-    <BitmapImage x:Key="diddy" UriSource="Images\dk64\diddy.png"  x:Shared="false"/>
-    <BitmapImage x:Key="lanky" UriSource="Images\dk64\lanky.png"  x:Shared="false" />
-    <BitmapImage x:Key="tiny" UriSource="Images\dk64\tiny.png"  x:Shared="false" />
-    <BitmapImage x:Key="chunky" UriSource="Images\dk64\chunky.png"  x:Shared="false" />
+    <BitmapImage x:Key="donkey_krool" UriSource="Images/dk64/krool-donkey.png"  x:Shared="false"/>
+    <BitmapImage x:Key="diddy_krool" UriSource="Images/dk64/krool-diddy.png"  x:Shared="false"/>
+    <BitmapImage x:Key="lanky_krool" UriSource="Images/dk64/krool-lanky.png"  x:Shared="false" />
+    <BitmapImage x:Key="tiny_krool" UriSource="Images/dk64/krool-tiny.png"  x:Shared="false" />
+    <BitmapImage x:Key="chunky_krool" UriSource="Images/dk64/krool-chunky.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="coconut_gun" UriSource="Images\dk64\dk_gun.png"  x:Shared="false" />
-    <BitmapImage x:Key="peanut_popguns" UriSource="Images\dk64\diddy_gun.png"  x:Shared="false"/>
-    <BitmapImage x:Key="grape_shooter" UriSource="Images\dk64\lanky_gun.png"  x:Shared="false" />
-    <BitmapImage x:Key="feather_bow" UriSource="Images\dk64\tiny_gun.png"  x:Shared="false"/>
-    <BitmapImage x:Key="pineapple_launcher" UriSource="Images\dk64\chunky_gun.png"  x:Shared="false"/>
+    <BitmapImage x:Key="donkey" UriSource="Images/dk64/donkey.png"  x:Shared="false"/>
+    <BitmapImage x:Key="diddy" UriSource="Images/dk64/diddy.png"  x:Shared="false"/>
+    <BitmapImage x:Key="lanky" UriSource="Images/dk64/lanky.png"  x:Shared="false" />
+    <BitmapImage x:Key="tiny" UriSource="Images/dk64/tiny.png"  x:Shared="false" />
+    <BitmapImage x:Key="chunky" UriSource="Images/dk64/chunky.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="bongo_blast" UriSource="Images\dk64\dk_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="guitar_gazump" UriSource="Images\dk64\diddy_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="trombone_tremor" UriSource="Images\dk64\lanky_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="saxophone_slam" UriSource="Images\dk64\tiny_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="triangle_trample" UriSource="Images\dk64\chunky_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="coconut_gun" UriSource="Images/dk64/dk_gun.png"  x:Shared="false" />
+    <BitmapImage x:Key="peanut_popguns" UriSource="Images/dk64/diddy_gun.png"  x:Shared="false"/>
+    <BitmapImage x:Key="grape_shooter" UriSource="Images/dk64/lanky_gun.png"  x:Shared="false" />
+    <BitmapImage x:Key="feather_bow" UriSource="Images/dk64/tiny_gun.png"  x:Shared="false"/>
+    <BitmapImage x:Key="pineapple_launcher" UriSource="Images/dk64/chunky_gun.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="gorilla_grab" UriSource="Images\dk64\dk_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="chimpy_charge" UriSource="Images\dk64\diddy_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="orangstand" UriSource="Images\dk64\lanky_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="ponytail_twirl" UriSource="Images\dk64\tiny_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="primate_punch" UriSource="Images\dk64\chunky_move.png"  x:Shared="false" />
-    
-    <BitmapImage x:Key="baboon_balloon" UriSource="Images\dk64\lankypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="bongo_blast" UriSource="Images/dk64/dk_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="guitar_gazump" UriSource="Images/dk64/diddy_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="trombone_tremor" UriSource="Images/dk64/lanky_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="saxophone_slam" UriSource="Images/dk64/tiny_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="triangle_trample" UriSource="Images/dk64/chunky_inst.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="key_1" UriSource="Images\dk64\k1.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_2" UriSource="Images\dk64\k2.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_3" UriSource="Images\dk64\k3.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_4" UriSource="Images\dk64\k4.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_5" UriSource="Images\dk64\k5.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_6" UriSource="Images\dk64\k6.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_7" UriSource="Images\dk64\k7.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_8" UriSource="Images\dk64\k8.png"  x:Shared="false"/>
+    <BitmapImage x:Key="gorilla_grab" UriSource="Images/dk64/dk_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="chimpy_charge" UriSource="Images/dk64/diddy_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="orangstand" UriSource="Images/dk64/lanky_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="ponytail_twirl" UriSource="Images/dk64/tiny_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="primate_punch" UriSource="Images/dk64/chunky_move.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="basic_key" UriSource="Images\dk64\key.png"  x:Shared="false"/>
+    <BitmapImage x:Key="strong_kong" UriSource="Images/dk64/dkbarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="rocketbarrel_boost" UriSource="Images/dk64/diddybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="orangstand_sprint" UriSource="Images/dk64/lankybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="mini_monkey" UriSource="Images/dk64/tinybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="hunky_chunky" UriSource="Images/dk64/chunkybarrel.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="unknown_vial" UriSource="Images\dk64\unknown_vial.png"  x:Shared="false"/>
-    <BitmapImage x:Key="unknown_key" UriSource="Images\dk64\unknown_key.png"  x:Shared="false"/>
+    <BitmapImage x:Key="baboon_blast" UriSource="Images/dk64/dkpad.png"  x:Shared="false" />
+    <BitmapImage x:Key="simian_spring" UriSource="Images/dk64/diddypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="baboon_balloon" UriSource="Images/dk64/lankypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="monkeyport" UriSource="Images/dk64/tinypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="progressive_slam_1" UriSource="Images\dk64\progressive_slam.png"  x:Shared="false"/>
-    <BitmapImage x:Key="progressive_slam_2" UriSource="Images\dk64\progressive_slam.png"  x:Shared="false"/>
-    <BitmapImage x:Key="progressive_slam_3" UriSource="Images\dk64\progressive_slam.png"  x:Shared="false"/>
-    <BitmapImage x:Key="fairy_camera" UriSource="Images\dk64\fairy_camera.png"  x:Shared="false"/>
-    <BitmapImage x:Key="shockwave" UriSource="Images\dk64\shockwave.png"  x:Shared="false"/>
-    <BitmapImage x:Key="sniper_scope" UriSource="Images\dk64\sniper_scope.png"  x:Shared="false"/>
-    <BitmapImage x:Key="homing_ammo" UriSource="Images\dk64\homing_ammo.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_1" UriSource="Images/dk64/k1.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_2" UriSource="Images/dk64/k2.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_3" UriSource="Images/dk64/k3.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_4" UriSource="Images/dk64/k4.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_5" UriSource="Images/dk64/k5.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_6" UriSource="Images/dk64/k6.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_7" UriSource="Images/dk64/k7.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_8" UriSource="Images/dk64/k8.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="diving" UriSource="Images\dk64\diving.png"  x:Shared="false"/>
-    <BitmapImage x:Key="orange_throwing" UriSource="Images\dk64\orange_throwing.png"  x:Shared="false"/>
-    <BitmapImage x:Key="barrel_throwing" UriSource="Images\dk64\barrel_throwing.png"  x:Shared="false"/>
-    <BitmapImage x:Key="vine_swinging" UriSource="Images\dk64\vine_swinging.png"  x:Shared="false"/>
-    <BitmapImage x:Key="climbing" UriSource="Images\dk64\climbing.png"  x:Shared="false"/>
+    <BitmapImage x:Key="basic_key" UriSource="Images/dk64/key.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="bean" UriSource="Images\dk64\bean.png"  x:Shared="false"/>
+    <BitmapImage x:Key="unknown_vial" UriSource="Images/dk64/unknown_vial.png"  x:Shared="false"/>
+    <BitmapImage x:Key="unknown_key" UriSource="Images/dk64/unknown_key.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="rareware_coin" UriSource="Images\dk64\rareware_coin.png"  x:Shared="false"/>
-    <BitmapImage x:Key="nintendo_coin" UriSource="Images\dk64\nintendo_coin.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_1" UriSource="Images/dk64/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_2" UriSource="Images/dk64/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_3" UriSource="Images/dk64/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_1_bc" UriSource="Images/dk64/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_2_bc" UriSource="Images/dk64/slam2.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_3_bc" UriSource="Images/dk64/slam3.png"  x:Shared="false"/>
+    <BitmapImage x:Key="fairy_camera" UriSource="Images/dk64/fairy_camera.png"  x:Shared="false"/>
+    <BitmapImage x:Key="shockwave" UriSource="Images/dk64/shockwave.png"  x:Shared="false"/>
+    <BitmapImage x:Key="sniper_scope" UriSource="Images/dk64/sniper_scope.png"  x:Shared="false"/>
+    <BitmapImage x:Key="homing_ammo" UriSource="Images/dk64/homing_ammo.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="pearl" UriSource="Images\dk64\pearl.png"  x:Shared="false"/>
+    <BitmapImage x:Key="diving" UriSource="Images/dk64/diving.png"  x:Shared="false"/>
+    <BitmapImage x:Key="orange_throwing" UriSource="Images/dk64/orange_throwing.png"  x:Shared="false"/>
+    <BitmapImage x:Key="barrel_throwing" UriSource="Images/dk64/barrel_throwing.png"  x:Shared="false"/>
+    <BitmapImage x:Key="vine_swinging" UriSource="Images/dk64/vine_swinging.png"  x:Shared="false"/>
+    <BitmapImage x:Key="climbing" UriSource="Images/dk64/climbing.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="potion_dk" UriSource="Images\dk64\yellow_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_diddy" UriSource="Images\dk64\red_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_lanky" UriSource="Images\dk64\blue_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_tiny" UriSource="Images\dk64\purple_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_chunky" UriSource="Images\dk64\green_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_shared" UriSource="Images\dk64\clear_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="kong_family" UriSource="Images\dk64\tag_barrel.png" x:Shared="false"/>
+    <BitmapImage x:Key="rareware_coin" UriSource="Images/dk64/rareware_coin.png"  x:Shared="false"/>
+    <BitmapImage x:Key="nintendo_coin" UriSource="Images/dk64/nintendo_coin.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="cranky" UriSource="Images\dk64\cranky.png" x:Shared="false"/>
-    <BitmapImage x:Key="candy" UriSource="Images\dk64\candy.png" x:Shared="false"/>
-    <BitmapImage x:Key="funky" UriSource="Images\dk64\funky.png" x:Shared="false"/>
-    <BitmapImage x:Key="snide" UriSource="Images\dk64\snide.png" x:Shared="false"/>
+    <BitmapImage x:Key="golden_banana" UriSource="Images/dk64/GB.png"  x:Shared="false"/>
+    <BitmapImage x:Key="blueprint" UriSource="Images/dk64/bp.png"  x:Shared="false"/>
+    <BitmapImage x:Key="pearl" UriSource="Images/dk64/pearl.png"  x:Shared="false"/>
+    <BitmapImage x:Key="crown" UriSource="Images/dk64/crown.png"  x:Shared="false"/>
+    <BitmapImage x:Key="medal" UriSource="Images/dk64/bananamedal.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rainbow_coin" UriSource="Images/dk64/rainbowcoin.png"  x:Shared="false"/>
+    <BitmapImage x:Key="fairy" UriSource="Images/dk64/fairy.png"  x:Shared="false"/>
+    <BitmapImage x:Key="company_coin" UriSource="Images/dk64/ninrarecoin.png"  x:Shared="false"/>
+    <BitmapImage x:Key="bean" UriSource="Images/dk64/bean.png"  x:Shared="false"/>
+    <BitmapImage x:Key="colored_bananas" UriSource="Images/dk64/colored_bananas.png"  x:Shared="false"/>
+    <BitmapImage x:Key="total_blueprints" UriSource="Images/dk64/total_bps.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="army" UriSource="Images\dk64\army.png" x:Shared="false"/>
-    <BitmapImage x:Key="army2" UriSource="Images\dk64\army2.png" x:Shared="false"/>
-    <BitmapImage x:Key="doga" UriSource="Images\dk64\doga.png" x:Shared="false"/>
-    <BitmapImage x:Key="doga2" UriSource="Images\dk64\doga2.png" x:Shared="false"/>
-    <BitmapImage x:Key="pufftoss" UriSource="Images\dk64\pufftoss.png" x:Shared="false"/>
-    <BitmapImage x:Key="madjack" UriSource="Images\dk64\madjack.png" x:Shared="false"/>
-    <BitmapImage x:Key="kutout" UriSource="Images\dk64\kutout.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_dk" UriSource="Images/dk64/yellow_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_diddy" UriSource="Images/dk64/red_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_lanky" UriSource="Images/dk64/blue_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_tiny" UriSource="Images/dk64/purple_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_chunky" UriSource="Images/dk64/green_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_shared" UriSource="Images/dk64/clear_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="kong_family" UriSource="Images/dk64/tag_barrel.png" x:Shared="false"/>
 
-    <BitmapImage x:Key="hint" UriSource="Images\dk64\hint.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_clear" UriSource="Images/dk64/clear_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_yellow" UriSource="Images/dk64/yellow_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_red" UriSource="Images/dk64/red_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_blue" UriSource="Images/dk64/blue_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_purple" UriSource="Images/dk64/purple_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_green" UriSource="Images/dk64/green_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_key" UriSource="Images/dk64/key_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="vial_kong" UriSource="Images/dk64/kong_vial.png" x:Shared="false"/>
+
+    <BitmapImage x:Key="cranky" UriSource="Images/dk64/cranky.png" x:Shared="false"/>
+    <BitmapImage x:Key="candy" UriSource="Images/dk64/candy.png" x:Shared="false"/>
+    <BitmapImage x:Key="funky" UriSource="Images/dk64/funky.png" x:Shared="false"/>
+    <BitmapImage x:Key="snide" UriSource="Images/dk64/snide.png" x:Shared="false"/>
+
+    <BitmapImage x:Key="army" UriSource="Images/dk64/army.png" x:Shared="false"/>
+    <BitmapImage x:Key="army2" UriSource="Images/dk64/army2.png" x:Shared="false"/>
+    <BitmapImage x:Key="doga" UriSource="Images/dk64/doga.png" x:Shared="false"/>
+    <BitmapImage x:Key="doga2" UriSource="Images/dk64/doga2.png" x:Shared="false"/>
+    <BitmapImage x:Key="pufftoss" UriSource="Images/dk64/pufftoss.png" x:Shared="false"/>
+    <BitmapImage x:Key="madjack" UriSource="Images/dk64/madjack.png" x:Shared="false"/>
+    <BitmapImage x:Key="kutout" UriSource="Images/dk64/kutout.png" x:Shared="false"/>
+
+    <BitmapImage x:Key="homing_scope" UriSource="Images/dk64/homingscope.png" x:Shared="false"/>
+    <BitmapImage x:Key="scopeonly" UriSource="Images/dk64/scopeonly.png" x:Shared="false"/>
+    <BitmapImage x:Key="homingonly" UriSource="Images/dk64/homingonly.png" x:Shared="false"/>
+    <BitmapImage x:Key="camera_shockwave" UriSource="Images/dk64/filmwave.png" x:Shared="false"/>
+    <BitmapImage x:Key="fairycamonly" UriSource="Images/dk64/fairycamonly.png" x:Shared="false"/>
+    <BitmapImage x:Key="shockwaveonly" UriSource="Images/dk64/shockwaveonly.png" x:Shared="false"/>
+
+    <BitmapImage x:Key="hint" UriSource="Images/dk64/hint.png" x:Shared="false"/>
+    <BitmapImage x:Key="filter_empty" UriSource="Images/dk64/filter_empty.png" x:Shared="false"/>
+    <BitmapImage x:Key="filter_on" UriSource="Images/dk64/filter_on.png" x:Shared="false"/>
+    <BitmapImage x:Key="sort" UriSource="Images/dk64/sort.png" x:Shared="false"/>
 
     <!--Black&White-->
-    <BitmapImage x:Key="potion_dk_bw" UriSource="Images\bw\yellow_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_diddy_bw" UriSource="Images\bw\red_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_lanky_bw" UriSource="Images\bw\blue_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_tiny_bw" UriSource="Images\bw\purple_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_chunky_bw" UriSource="Images\bw\green_vial.png" x:Shared="false"/>
-    <BitmapImage x:Key="potion_shared_bw" UriSource="Images\bw\clear_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="unknown_kong_bw" UriSource="Images/bw/unknown_kong.png" x:Shared="false" />
+    <BitmapImage x:Key="dk_isles_bw" UriSource="Images/bw/dk_isles.png" x:Shared="false" />
+    <BitmapImage x:Key="start_bw" UriSource="Images/bw/start.png" x:Shared="false" />
+
+    <BitmapImage x:Key="potion_dk_bw" UriSource="Images/bw/yellow_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_diddy_bw" UriSource="Images/bw/red_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_lanky_bw" UriSource="Images/bw/blue_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_tiny_bw" UriSource="Images/bw/purple_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_chunky_bw" UriSource="Images/bw/green_vial.png" x:Shared="false"/>
+    <BitmapImage x:Key="potion_shared_bw" UriSource="Images/bw/clear_vial.png" x:Shared="false"/>
     
-    <BitmapImage x:Key="donkey_krool_bw" UriSource="Images\bw\krool-donkey.png"  x:Shared="false"/>
-    <BitmapImage x:Key="diddy_krool_bw" UriSource="Images\bw\krool-diddy.png"  x:Shared="false"/>
-    <BitmapImage x:Key="lanky_krool_bw" UriSource="Images\bw\krool-lanky.png"  x:Shared="false" />
-    <BitmapImage x:Key="tiny_krool_bw" UriSource="Images\bw\krool-tiny.png"  x:Shared="false" />
-    <BitmapImage x:Key="chunky_krool_bw" UriSource="Images\bw\krool-chunky.png"  x:Shared="false" />
+    <BitmapImage x:Key="donkey_krool_bw" UriSource="Images/bw/krool-donkey.png"  x:Shared="false"/>
+    <BitmapImage x:Key="diddy_krool_bw" UriSource="Images/bw/krool-diddy.png"  x:Shared="false"/>
+    <BitmapImage x:Key="lanky_krool_bw" UriSource="Images/bw/krool-lanky.png"  x:Shared="false" />
+    <BitmapImage x:Key="tiny_krool_bw" UriSource="Images/bw/krool-tiny.png"  x:Shared="false" />
+    <BitmapImage x:Key="chunky_krool_bw" UriSource="Images/bw/krool-chunky.png"  x:Shared="false" />
     
-    <BitmapImage x:Key="donkey_bw" UriSource="Images\bw\donkey.png"  x:Shared="false"/>
-    <BitmapImage x:Key="diddy_bw" UriSource="Images\bw\diddy.png"  x:Shared="false"/>
-    <BitmapImage x:Key="lanky_bw" UriSource="Images\bw\lanky.png"  x:Shared="false" />
-    <BitmapImage x:Key="tiny_bw" UriSource="Images\bw\tiny.png"  x:Shared="false" />
-    <BitmapImage x:Key="chunky_bw" UriSource="Images\bw\chunky.png"  x:Shared="false" />
+    <BitmapImage x:Key="donkey_bw" UriSource="Images/bw/donkey.png"  x:Shared="false"/>
+    <BitmapImage x:Key="diddy_bw" UriSource="Images/bw/diddy.png"  x:Shared="false"/>
+    <BitmapImage x:Key="lanky_bw" UriSource="Images/bw/lanky.png"  x:Shared="false" />
+    <BitmapImage x:Key="tiny_bw" UriSource="Images/bw/tiny.png"  x:Shared="false" />
+    <BitmapImage x:Key="chunky_bw" UriSource="Images/bw/chunky.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="coconut_gun_bw" UriSource="Images\bw\dk_gun.png"  x:Shared="false" />
-    <BitmapImage x:Key="peanut_popguns_bw" UriSource="Images\bw\diddy_gun.png"  x:Shared="false"/>
-    <BitmapImage x:Key="grape_shooter_bw" UriSource="Images\bw\lanky_gun.png"  x:Shared="false" />
-    <BitmapImage x:Key="feather_bow_bw" UriSource="Images\bw\tiny_gun.png"  x:Shared="false" />
-    <BitmapImage x:Key="pineapple_launcher_bw" UriSource="Images\bw\chunky_gun.png"  x:Shared="false"/>
+    <BitmapImage x:Key="coconut_gun_bw" UriSource="Images/bw/dk_gun.png"  x:Shared="false" />
+    <BitmapImage x:Key="peanut_popguns_bw" UriSource="Images/bw/diddy_gun.png"  x:Shared="false"/>
+    <BitmapImage x:Key="grape_shooter_bw" UriSource="Images/bw/lanky_gun.png"  x:Shared="false" />
+    <BitmapImage x:Key="feather_bow_bw" UriSource="Images/bw/tiny_gun.png"  x:Shared="false" />
+    <BitmapImage x:Key="pineapple_launcher_bw" UriSource="Images/bw/chunky_gun.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="bongo_blast_bw" UriSource="Images\bw\dk_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="guitar_gazump_bw" UriSource="Images\bw\diddy_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="trombone_tremor_bw" UriSource="Images\bw\lanky_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="saxophone_slam_bw" UriSource="Images\bw\tiny_inst.png"  x:Shared="false" />
-    <BitmapImage x:Key="triangle_trample_bw" UriSource="Images\bw\chunky_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="bongo_blast_bw" UriSource="Images/bw/dk_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="guitar_gazump_bw" UriSource="Images/bw/diddy_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="trombone_tremor_bw" UriSource="Images/bw/lanky_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="saxophone_slam_bw" UriSource="Images/bw/tiny_inst.png"  x:Shared="false" />
+    <BitmapImage x:Key="triangle_trample_bw" UriSource="Images/bw/chunky_inst.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="gorilla_grab_bw" UriSource="Images\bw\dk_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="chimpy_charge_bw" UriSource="Images\bw\diddy_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="orangstand_bw" UriSource="Images\bw\lanky_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="ponytail_twirl_bw" UriSource="Images\bw\tiny_move.png"  x:Shared="false" />
-    <BitmapImage x:Key="primate_punch_bw" UriSource="Images\bw\chunky_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="gorilla_grab_bw" UriSource="Images/bw/dk_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="chimpy_charge_bw" UriSource="Images/bw/diddy_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="orangstand_bw" UriSource="Images/bw/lanky_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="ponytail_twirl_bw" UriSource="Images/bw/tiny_move.png"  x:Shared="false" />
+    <BitmapImage x:Key="primate_punch_bw" UriSource="Images/bw/chunky_move.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="strong_kong_bw" UriSource="Images\bw\dkbarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images\bw\diddybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images\bw\lankybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images\bw\tinybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images\bw\chunkybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="strong_kong_bw" UriSource="Images/bw/dkbarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images/bw/diddybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images/bw/lankybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images/bw/tinybarrel.png"  x:Shared="false" />
+    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images/bw/chunkybarrel.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images\bw\dkpad.png"  x:Shared="false" />
-    <BitmapImage x:Key="simian_spring_bw" UriSource="Images\bw\diddypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="baboon_balloon_bw" UriSource="Images\bw\lankypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="monkeyport_bw" UriSource="Images\bw\tinypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images\bw\chunkypad.png"  x:Shared="false"/>
+    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images/bw/dkpad.png"  x:Shared="false" />
+    <BitmapImage x:Key="simian_spring_bw" UriSource="Images/bw/diddypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="baboon_balloon_bw" UriSource="Images/bw/lankypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="monkeyport_bw" UriSource="Images/bw/tinypad.png"  x:Shared="false" />
+    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="key_1_bw" UriSource="Images\bw\k1.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_2_bw" UriSource="Images\bw\k2.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_3_bw" UriSource="Images\bw\k3.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_4_bw" UriSource="Images\bw\k4.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_5_bw" UriSource="Images\bw\k5.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_6_bw" UriSource="Images\bw\k6.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_7_bw" UriSource="Images\bw\k7.png"  x:Shared="false"/>
-    <BitmapImage x:Key="key_8_bw" UriSource="Images\bw\k8.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_1_bw" UriSource="Images/bw/k1.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_2_bw" UriSource="Images/bw/k2.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_3_bw" UriSource="Images/bw/k3.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_4_bw" UriSource="Images/bw/k4.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_5_bw" UriSource="Images/bw/k5.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_6_bw" UriSource="Images/bw/k6.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_7_bw" UriSource="Images/bw/k7.png"  x:Shared="false"/>
+    <BitmapImage x:Key="key_8_bw" UriSource="Images/bw/k8.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="basic_key_bw" UriSource="Images\bw\key.png"  x:Shared="false"/>
+    <BitmapImage x:Key="basic_key_bw" UriSource="Images/bw/key.png"  x:Shared="false"/>
     
-    <BitmapImage x:Key="unknown_vial_bw" UriSource="Images\bw\unknown_vial.png"  x:Shared="false"/>
-    <BitmapImage x:Key="unknown_key_bw" UriSource="Images\bw\unknown_key.png"  x:Shared="false"/>
+    <BitmapImage x:Key="unknown_vial_bw" UriSource="Images/bw/unknown_vial.png"  x:Shared="false"/>
+    <BitmapImage x:Key="unknown_key_bw" UriSource="Images/bw/unknown_key.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="progressive_slam_1_bw" UriSource="Images\bw\progressive_slam.png"  x:Shared="false"/>
-    <BitmapImage x:Key="progressive_slam_2_bw" UriSource="Images\bw\progressive_slam.png"  x:Shared="false"/>
-    <BitmapImage x:Key="progressive_slam_3_bw" UriSource="Images\bw\progressive_slam.png"  x:Shared="false"/>
-    <BitmapImage x:Key="fairy_camera_bw" UriSource="Images\bw\film.png"  x:Shared="false"/>
-    <BitmapImage x:Key="shockwave_bw" UriSource="Images\bw\shockwave.png"  x:Shared="false"/>
-    <BitmapImage x:Key="sniper_scope_bw" UriSource="Images\bw\sniper_scope.png"  x:Shared="false"/>
-    <BitmapImage x:Key="homing_ammo_bw" UriSource="Images\bw\homing_ammo.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_1_bw" UriSource="Images/bw/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_2_bw" UriSource="Images/bw/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_3_bw" UriSource="Images/bw/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_1_bc_bw" UriSource="Images/bw/progressive_slam.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_2_bc_bw" UriSource="Images/bw/slam2.png"  x:Shared="false"/>
+    <BitmapImage x:Key="progressive_slam_3_bc_bw" UriSource="Images/bw/slam3.png"  x:Shared="false"/>
+    <BitmapImage x:Key="fairy_camera_bw" UriSource="Images/bw/film.png"  x:Shared="false"/>
+    <BitmapImage x:Key="shockwave_bw" UriSource="Images/bw/shockwave.png"  x:Shared="false"/>
+    <BitmapImage x:Key="sniper_scope_bw" UriSource="Images/bw/sniper_scope.png"  x:Shared="false"/>
+    <BitmapImage x:Key="homing_ammo_bw" UriSource="Images/bw/homing_ammo.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="diving_bw" UriSource="Images\bw\diving.png"  x:Shared="false"/>
-    <BitmapImage x:Key="orange_throwing_bw" UriSource="Images\bw\orange_throwing.png"  x:Shared="false"/>
-    <BitmapImage x:Key="barrel_throwing_bw" UriSource="Images\bw\barrel_throwing.png"  x:Shared="false"/>
-    <BitmapImage x:Key="vine_swinging_bw" UriSource="Images\bw\vine_swinging.png"  x:Shared="false"/>
-    <BitmapImage x:Key="climbing_bw" UriSource="Images\bw\climbing.png"  x:Shared="false"/>
+    <BitmapImage x:Key="diving_bw" UriSource="Images/bw/diving.png"  x:Shared="false"/>
+    <BitmapImage x:Key="orange_throwing_bw" UriSource="Images/bw/orange_throwing.png"  x:Shared="false"/>
+    <BitmapImage x:Key="barrel_throwing_bw" UriSource="Images/bw/barrel_throwing.png"  x:Shared="false"/>
+    <BitmapImage x:Key="vine_swinging_bw" UriSource="Images/bw/vine_swinging.png"  x:Shared="false"/>
+    <BitmapImage x:Key="climbing_bw" UriSource="Images/bw/climbing.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="bean_bw" UriSource="Images\bw\bean.png"  x:Shared="false"/>
-    
-    <BitmapImage x:Key="rareware_coin_bw" UriSource="Images\bw\rareware_coin.png"  x:Shared="false"/>
-    <BitmapImage x:Key="nintendo_coin_bw" UriSource="Images\bw\nintendo_coin.png"  x:Shared="false"/>
-    
-    <BitmapImage x:Key="kong_family_bw" UriSource="Images\bw\tag_barrel.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rareware_coin_bw" UriSource="Images/bw/rareware_coin.png"  x:Shared="false"/>
+    <BitmapImage x:Key="nintendo_coin_bw" UriSource="Images/bw/nintendo_coin.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="cranky_bw" UriSource="Images\bw\cranky.png" x:Shared="false"/>
-    <BitmapImage x:Key="candy_bw" UriSource="Images\bw\candy.png" x:Shared="false"/>
-    <BitmapImage x:Key="funky_bw" UriSource="Images\bw\funky.png" x:Shared="false"/>
-    <BitmapImage x:Key="snide_bw" UriSource="Images\bw\snide.png" x:Shared="false"/>
+    <BitmapImage x:Key="golden_banana_bw" UriSource="Images/bw/GB.png"  x:Shared="false"/>
+    <BitmapImage x:Key="blueprint_bw" UriSource="Images/bw/bp.png"  x:Shared="false"/>
+    <BitmapImage x:Key="pearl_bw" UriSource="Images/bw/pearl.png"  x:Shared="false"/>
+    <BitmapImage x:Key="crown_bw" UriSource="Images/bw/crown.png"  x:Shared="false"/>
+    <BitmapImage x:Key="medal_bw" UriSource="Images/bw/bananamedal.png"  x:Shared="false"/>
+    <BitmapImage x:Key="rainbow_coin_bw" UriSource="Images/bw/rainbowcoin.png"  x:Shared="false"/>
+    <BitmapImage x:Key="fairy_bw" UriSource="Images/bw/fairy.png"  x:Shared="false"/>
+    <BitmapImage x:Key="bean_bw" UriSource="Images/bw/bean.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="army_bw" UriSource="Images\bw\army.png" x:Shared="false"/>
-    <BitmapImage x:Key="army2_bw" UriSource="Images\bw\army2.png" x:Shared="false"/>
-    <BitmapImage x:Key="doga_bw" UriSource="Images\bw\doga.png" x:Shared="false"/>
-    <BitmapImage x:Key="doga2_bw" UriSource="Images\bw\doga2.png" x:Shared="false"/>
-    <BitmapImage x:Key="pufftoss_bw" UriSource="Images\bw\pufftoss.png" x:Shared="false"/>
-    <BitmapImage x:Key="madjack_bw" UriSource="Images\bw\madjack.png" x:Shared="false"/>
-    <BitmapImage x:Key="kutout_bw" UriSource="Images\bw\kutout.png" x:Shared="false"/>
+    <BitmapImage x:Key="kong_family_bw" UriSource="Images/bw/tag_barrel.png"  x:Shared="false"/>
 
-    <BitmapImage x:Key="homing_scope_bw" UriSource="Images\bw\homingscope.png" x:Shared="false"/>
-    <BitmapImage x:Key="camera_shockwave_bw" UriSource="Images\bw\filmwave.png" x:Shared="false"/>
+    <BitmapImage x:Key="cranky_bw" UriSource="Images/bw/cranky.png" x:Shared="false"/>
+    <BitmapImage x:Key="candy_bw" UriSource="Images/bw/candy.png" x:Shared="false"/>
+    <BitmapImage x:Key="funky_bw" UriSource="Images/bw/funky.png" x:Shared="false"/>
+    <BitmapImage x:Key="snide_bw" UriSource="Images/bw/snide.png" x:Shared="false"/>
 
-    <BitmapImage x:Key="hint_bw" UriSource="Images\bw\hint.png" x:Shared="false"/>
+    <BitmapImage x:Key="army_bw" UriSource="Images/bw/army.png" x:Shared="false"/>
+    <BitmapImage x:Key="army2_bw" UriSource="Images/bw/army2.png" x:Shared="false"/>
+    <BitmapImage x:Key="doga_bw" UriSource="Images/bw/doga.png" x:Shared="false"/>
+    <BitmapImage x:Key="doga2_bw" UriSource="Images/bw/doga2.png" x:Shared="false"/>
+    <BitmapImage x:Key="pufftoss_bw" UriSource="Images/bw/pufftoss.png" x:Shared="false"/>
+    <BitmapImage x:Key="madjack_bw" UriSource="Images/bw/madjack.png" x:Shared="false"/>
+    <BitmapImage x:Key="kutout_bw" UriSource="Images/bw/kutout.png" x:Shared="false"/>
+
+    <BitmapImage x:Key="homing_scope_bw" UriSource="Images/bw/homingscope.png" x:Shared="false"/>
+    <BitmapImage x:Key="camera_shockwave_bw" UriSource="Images/bw/filmwave.png" x:Shared="false"/>
+
+    <BitmapImage x:Key="hint_bw" UriSource="Images/bw/hint.png" x:Shared="false"/>
 
 </ResourceDictionary>

--- a/TrackOMatic/Dictionary1.xaml
+++ b/TrackOMatic/Dictionary1.xaml
@@ -83,17 +83,7 @@
     <BitmapImage x:Key="ponytail_twirl" UriSource="Images/dk64/tiny_move.png"  x:Shared="false" />
     <BitmapImage x:Key="primate_punch" UriSource="Images/dk64/chunky_move.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="strong_kong" UriSource="Images/dk64/dkbarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="rocketbarrel_boost" UriSource="Images/dk64/diddybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="orangstand_sprint" UriSource="Images/dk64/lankybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="mini_monkey" UriSource="Images/dk64/tinybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="hunky_chunky" UriSource="Images/dk64/chunkybarrel.png"  x:Shared="false" />
-
-    <BitmapImage x:Key="baboon_blast" UriSource="Images/dk64/dkpad.png"  x:Shared="false" />
-    <BitmapImage x:Key="simian_spring" UriSource="Images/dk64/diddypad.png"  x:Shared="false" />
     <BitmapImage x:Key="baboon_balloon" UriSource="Images/dk64/lankypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="monkeyport" UriSource="Images/dk64/tinypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="gorilla_gone" UriSource="Images/dk64/chunkypad.png"  x:Shared="false"/>
 
     <BitmapImage x:Key="key_1" UriSource="Images/dk64/k1.png"  x:Shared="false"/>
     <BitmapImage x:Key="key_2" UriSource="Images/dk64/k2.png"  x:Shared="false"/>
@@ -225,17 +215,7 @@
     <BitmapImage x:Key="ponytail_twirl_bw" UriSource="Images/bw/tiny_move.png"  x:Shared="false" />
     <BitmapImage x:Key="primate_punch_bw" UriSource="Images/bw/chunky_move.png"  x:Shared="false" />
 
-    <BitmapImage x:Key="strong_kong_bw" UriSource="Images/bw/dkbarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="rocketbarrel_boost_bw" UriSource="Images/bw/diddybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="orangstand_sprint_bw" UriSource="Images/bw/lankybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="mini_monkey_bw" UriSource="Images/bw/tinybarrel.png"  x:Shared="false" />
-    <BitmapImage x:Key="hunky_chunky_bw" UriSource="Images/bw/chunkybarrel.png"  x:Shared="false" />
-
-    <BitmapImage x:Key="baboon_blast_bw" UriSource="Images/bw/dkpad.png"  x:Shared="false" />
-    <BitmapImage x:Key="simian_spring_bw" UriSource="Images/bw/diddypad.png"  x:Shared="false" />
     <BitmapImage x:Key="baboon_balloon_bw" UriSource="Images/bw/lankypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="monkeyport_bw" UriSource="Images/bw/tinypad.png"  x:Shared="false" />
-    <BitmapImage x:Key="gorilla_gone_bw" UriSource="Images/bw/chunkypad.png"  x:Shared="false"/>
 
     <BitmapImage x:Key="key_1_bw" UriSource="Images/bw/k1.png"  x:Shared="false"/>
     <BitmapImage x:Key="key_2_bw" UriSource="Images/bw/k2.png"  x:Shared="false"/>

--- a/TrackOMatic/HintsUI/BLockerHint.xaml.cs
+++ b/TrackOMatic/HintsUI/BLockerHint.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 using TrackOMatic.Data;
@@ -15,23 +16,20 @@ namespace TrackOMatic
             set { SetValue(RegionNameProperty, value); }
         }
 
-        public static BitmapImage GetBarrierItemImage(BarrierItems item) =>
+        public BitmapImage GetBarrierItemImage(BarrierItems item) =>
             item switch
             {
-                BarrierItems.GOLDEN_BANANA => MakeImage("gb.png"),
-                BarrierItems.BLUEPRINT => MakeImage("bp.png"),
-                BarrierItems.PEARL => MakeImage("pearl.png"),
-                BarrierItems.CROWN => MakeImage("crown.png"),
-                BarrierItems.MEDAL => MakeImage("bananamedal.png"),
-                BarrierItems.RAINBOW_COIN => MakeImage("rainbowcoin.png"),
-                BarrierItems.FAIRY => MakeImage("fairy.png"),
-                BarrierItems.COMPANY_COIN => MakeImage("ninrarecoin.png"),
-                BarrierItems.BEAN => MakeImage("bean.png"),
+                BarrierItems.GOLDEN_BANANA => (BitmapImage)FindResource("golden_banana"),
+                BarrierItems.BLUEPRINT => (BitmapImage)FindResource("blueprint"),
+                BarrierItems.PEARL => (BitmapImage)FindResource("pearl"),
+                BarrierItems.CROWN => (BitmapImage)FindResource("crown"),
+                BarrierItems.MEDAL => (BitmapImage)FindResource("medal"),
+                BarrierItems.RAINBOW_COIN => (BitmapImage)FindResource("rainbow_coin"),
+                BarrierItems.FAIRY => (BitmapImage)FindResource("fairy"),
+                BarrierItems.COMPANY_COIN => (BitmapImage)FindResource("company_coin"),
+                BarrierItems.BEAN => (BitmapImage)FindResource("bean"),
                 _ => throw new ArgumentException($"Unknown barrier item: {item}")
             };
-
-        private static BitmapImage MakeImage(string filename) =>
-            new(new Uri("Images/dk64/" + filename, UriKind.Relative));
 
         public BLockerHint()
         {
@@ -55,7 +53,7 @@ namespace TrackOMatic
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            Picture.Source = new BitmapImage(new Uri("../Images/dk64/" + RegionName.ToString().ToLower() + ".png", UriKind.Relative));
+            Picture.Source = (ImageSource)FindResource(RegionName.ToString().ToLowerInvariant());
         }
 
     }

--- a/TrackOMatic/HintsUI/HelmDoorHint.xaml.cs
+++ b/TrackOMatic/HintsUI/HelmDoorHint.xaml.cs
@@ -21,18 +21,18 @@ namespace TrackOMatic
             {
                 new()
                 {
-                    new BitmapImage( new Uri("images/dk64/gb.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/bp.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/pearl.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/crown.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/bananamedal.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/rainbowcoin.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/fairy.png", UriKind.Relative)),
+                    (BitmapImage)FindResource("golden_banana"),
+                    (BitmapImage)FindResource("blueprint"),
+                    (BitmapImage)FindResource("pearl"),
+                    (BitmapImage)FindResource("crown"),
+                    (BitmapImage)FindResource("medal"),
+                    (BitmapImage)FindResource("rainbow_coin"),
+                    (BitmapImage)FindResource("fairy"),
                 },
                 new()
                 {
-                    new BitmapImage( new Uri("images/dk64/ninrarecoin.png", UriKind.Relative)),
-                    new BitmapImage( new Uri("images/dk64/bean.png", UriKind.Relative)),
+                    (BitmapImage)FindResource("company_coin"),
+                    (BitmapImage)FindResource("bean"),
                 }
             };
             DoorItem.ImageSources = BLockerSources;

--- a/TrackOMatic/HintsUI/HintPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/HintPanel.xaml.cs
@@ -133,12 +133,8 @@ namespace TrackOMatic
 
         private void UpdateFilterImage()
         {
-            var source = "../Images/dk64/filter_empty.png";
-            if (ItemsToFilterBy.Count > 0)
-            {
-                source = "../Images/dk64/filter_on.png";
-            }
-            FilterButton.Source = new BitmapImage(new Uri(source, UriKind.Relative));
+            string resource = ItemsToFilterBy.Count > 0 ? "filter_on" : "filter_empty";
+            FilterButton.Source = (ImageSource)FindResource(resource);
         }
 
         private void ApplyFilter()

--- a/TrackOMatic/MainWindow.xaml
+++ b/TrackOMatic/MainWindow.xaml
@@ -194,7 +194,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="StartPicture" Source="Images\dk64\start.png" Grid.RowSpan="6" Grid.ColumnSpan="5" Margin="10"/>
+                                    <Image x:Name="StartPicture" Source="Images/dk64/start.png" Grid.RowSpan="6" Grid.ColumnSpan="5" Margin="10"/>
 
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
                                         <TextBlock x:Name="StartTopLabel" FontSize="{StaticResource BigFontSize}" Foreground="{StaticResource GBColor}" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right" FontFamily="{DynamicResource DK64Font}" Text="13" Visibility="Visible" Grid.RowSpan="1" VerticalAlignment="Center"/>
@@ -229,7 +229,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level1Picture" Source="Images\dk64\jungle_japes.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level1Picture" Source="Images/dk64/jungle_japes.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level1Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -264,7 +264,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level2Picture" Source="Images\dk64\angry_aztec.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level2Picture" Source="Images/dk64/angry_aztec.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level2Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -300,7 +300,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level3Picture" Source="Images\dk64\frantic_factory.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level3Picture" Source="Images/dk64/frantic_factory.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level3Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -336,7 +336,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level4Picture" Source="Images\dk64\gloomy_galleon.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level4Picture" Source="Images/dk64/gloomy_galleon.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level4Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -380,7 +380,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="DKIslesPicture" Source="Images\dk64\dk_isles.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="0,15,0,0"/>
+                                    <Image x:Name="DKIslesPicture" Source="Images/dk64/dk_isles.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="0,15,0,0"/>
 
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
                                         <TextBlock x:Name="DKIslesTopLabel" FontSize="{StaticResource BigFontSize}" Foreground="{StaticResource GBColor}" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right" FontFamily="{DynamicResource DK64Font}" Text="13" Visibility="Visible" Grid.RowSpan="1" VerticalAlignment="Center"/>
@@ -414,7 +414,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level5Picture" Source="Images\dk64\fungi_forest.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level5Picture" Source="Images/dk64/fungi_forest.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level5Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -450,7 +450,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level6Picture" Source="Images\dk64\crystal_caves.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level6Picture" Source="Images/dk64/crystal_caves.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level6Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -486,7 +486,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="Level7Picture" Source="Images\dk64\creepy_castle.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="Level7Picture" Source="Images/dk64/creepy_castle.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level7Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -522,7 +522,7 @@
                                         <ColumnDefinition Width=".3*"/>
                                     </Grid.ColumnDefinitions>
 
-                                    <Image x:Name="HideoutHelmPicture" Source="Images\dk64\hideout_helm.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
+                                    <Image x:Name="HideoutHelmPicture" Source="Images/dk64/hideout_helm.png" Grid.RowSpan="6" Grid.ColumnSpan="2" Margin="{StaticResource RegionPictureMargin}"/>
 
                                     <local:LevelOrderNumber x:Name="Level8Order" Grid.RowSpan="6" Grid.ColumnSpan="5"/>
                                     <Viewbox Grid.Row="1" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="3" HorizontalAlignment="Right">
@@ -605,7 +605,7 @@
                             </Viewbox>
                         </Grid>
                     </Grid>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="BlueprintsTotal" ImageSource="Images\bw\total_bps.png" Text="0" Grid.Column="4">
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="BlueprintsTotal" ImageSource="Images/bw/total_bps.png" Text="0" Grid.Column="4">
                         <local:CollectibleItem.Style>
                             <Style TargetType="{x:Type local:CollectibleItem}">
                                 <Setter Property="Visibility" Value="Hidden"/>
@@ -617,7 +617,7 @@
                             </Style>
                         </local:CollectibleItem.Style>
                     </local:CollectibleItem>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="CompanyCoinsTotal" ImageSource="Images\bw\company_coin.png" Text="0" Grid.Column="6">
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="CompanyCoinsTotal" ImageSource="Images/bw/company_coin.png" Text="0" Grid.Column="6">
                         <local:CollectibleItem.Style>
                             <Style TargetType="{x:Type local:CollectibleItem}">
                                 <Setter Property="Visibility" Value="Hidden"/>
@@ -629,12 +629,12 @@
                             </Style>
                         </local:CollectibleItem.Style>
                     </local:CollectibleItem>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="Pearls" ImageSource="Images\bw\pearl.png" Text="0" Grid.Column="8"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="BattleCrowns" ImageSource="Images\bw\crown.png" Text="0" Grid.Column="10"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="BananaMedals" ImageSource="Images\bw\bananamedal.png" Text="0" Grid.Column="12"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="RainbowCoins" ImageSource="Images\bw\rainbowcoin.png" Text="0" Grid.Column="14"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="Fairies" ImageSource="Images\bw\fairy.png" Text="0" Grid.Column="16"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="GBs" ImageSource="Images\bw\GB.png" Text="0" Grid.Column="18"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="Pearls" ImageSource="Images/bw/pearl.png" Text="0" Grid.Column="8"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="BattleCrowns" ImageSource="Images/bw/crown.png" Text="0" Grid.Column="10"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="BananaMedals" ImageSource="Images/bw/bananamedal.png" Text="0" Grid.Column="12"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="RainbowCoins" ImageSource="Images/bw/rainbowcoin.png" Text="0" Grid.Column="14"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="Fairies" ImageSource="Images/bw/fairy.png" Text="0" Grid.Column="16"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="GBs" ImageSource="Images/bw/GB.png" Text="0" Grid.Column="18"/>
                 </Grid>
                 <!-- Items -->
                 <Grid Name="ItemGrid" Grid.Row="4" Visibility="Visible"  Margin="0" >
@@ -738,11 +738,11 @@
                     <local:ItemBackground BackgroundItemImage="{DynamicResource gorilla_gone}"    Grid.Row="4" Grid.Column="5" Visibility="Hidden" Panel.ZIndex="-1" Tag="{x:Static local:ItemName.GORILLA_GONE}"/>
 
                     <!--Blueprints-->
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="DonkeyBPs" ImageSource="Images\bw\dk_bp.png" Text="0" Grid.Row="0" Grid.Column="6"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="DiddyBPs" ImageSource="Images\bw\diddy_bp.png" Text="0" Grid.Row="1" Grid.Column="6"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="LankyBPs" ImageSource="Images\bw\lanky_bp.png" Text="0" Grid.Row="2" Grid.Column="6"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="TinyBPs" ImageSource="Images\bw\tiny_bp.png" Text="0" Grid.Row="3" Grid.Column="6"/>
-                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="ChunkyBPs" ImageSource="Images\bw\chunky_bp.png" Text="0" Grid.Row="4" Grid.Column="6"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="DonkeyBPs" ImageSource="Images/bw/dk_bp.png" Text="0" Grid.Row="0" Grid.Column="6"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="DiddyBPs" ImageSource="Images/bw/diddy_bp.png" Text="0" Grid.Row="1" Grid.Column="6"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="LankyBPs" ImageSource="Images/bw/lanky_bp.png" Text="0" Grid.Row="2" Grid.Column="6"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="TinyBPs" ImageSource="Images/bw/tiny_bp.png" Text="0" Grid.Row="3" Grid.Column="6"/>
+                    <local:CollectibleItem BGColor="{StaticResource VeryDark}" x:Name="ChunkyBPs" ImageSource="Images/bw/chunky_bp.png" Text="0" Grid.Row="4" Grid.Column="6"/>
 
                     <!-- Keys-->
                     <local:Item x:Name="key_1"  ItemImage="{DynamicResource key_1_bw}" Grid.Row="0" Grid.Column="8" Panel.ZIndex="0" Tag="{x:Static local:ItemName.KEY_1}"/>
@@ -826,7 +826,7 @@
                             <ColumnDefinition Width="1*"/>
                             <ColumnDefinition Width="1*"/>
                         </Grid.ColumnDefinitions>
-                        <Image x:Name="HelmLabel" Source="Images\dk64\lanky_bp.png" Grid.Column="0" Margin="-1"/>
+                        <Image x:Name="HelmLabel" Source="Images/dk64/lanky_bp.png" Grid.Column="0" Margin="-1"/>
                         <local:ProgressiveItem  x:Name="HelmKong1"  Opacity="1" Grid.Column="2" Margin="1" />
                         <local:ProgressiveItem x:Name="HelmKong2" Opacity="1"  Grid.Column="3" Margin="1" />
                         <local:ProgressiveItem  x:Name="HelmKong3"  Opacity="1" Grid.Column="4" Margin="1" />
@@ -844,7 +844,7 @@
                             <ColumnDefinition Width="1*"/>
                             <ColumnDefinition Width="1*"/>
                         </Grid.ColumnDefinitions>
-                        <Image x:Name="KRoolLabel" Source="Images\dk64\krool.png" Grid.Column="0" Margin="-1"/>
+                        <Image x:Name="KRoolLabel" Source="Images/dk64/krool.png" Grid.Column="0" Margin="-1"/>
                         <local:ProgressiveItem  x:Name="BossKong1"  Opacity="1" Grid.Column="2" Margin="1" />
                         <local:ProgressiveItem x:Name="BossKong2" Opacity="1"  Grid.Column="3" Margin="1" />
                         <local:ProgressiveItem  x:Name="BossKong3"  Opacity="1" Grid.Column="4" Margin="1" />
@@ -885,7 +885,7 @@
                                 <RowDefinition Height="1*" />
                                 <RowDefinition Height=".12*"/>
                             </Grid.RowDefinitions>
-                            <Image x:Name="Headphones" Grid.Row="1" Source="Images\dk64\headphones.png" Grid.Column="0" Margin="0" Panel.ZIndex="2" Opacity="1" HorizontalAlignment="Center"/>
+                            <Image x:Name="Headphones" Grid.Row="1" Source="Images/dk64/headphones.png" Grid.Column="0" Margin="0" Panel.ZIndex="2" Opacity="1" HorizontalAlignment="Center"/>
                         </Grid>
                         <Grid Grid.Column="1" Margin="0,0,0,0" >
                             <Grid.RowDefinitions>

--- a/TrackOMatic/MainWindow.xaml.cs
+++ b/TrackOMatic/MainWindow.xaml.cs
@@ -42,25 +42,8 @@ namespace TrackOMatic
         public DataSaver DataSaver { get; private set; }
         public SpoilerSettings SpoilerSettings { get; private set; } = null!;
 
-        private List<BitmapImage> ProgressiveKongSource = new()
-        {
-                new BitmapImage( new Uri("images/bw/unknown_kong.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/donkey.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/diddy.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/lanky.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/tiny.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/chunky.png", UriKind.Relative)),
-        };
-        private List<BitmapImage> BossSource = new()
-        {
-                new BitmapImage( new Uri("images/dk64/army.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/doga.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/madjack.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/pufftoss.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/doga2.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/army2.png", UriKind.Relative)),
-                new BitmapImage( new Uri("images/dk64/kutout.png", UriKind.Relative)),
-        };
+        private List<BitmapImage> ProgressiveKongSource { get; init; }
+        private List<BitmapImage> BossSource { get; init; }
 
         public Dictionary<ItemName, PathOrFoundItem> ITEM_TO_DIRECT_HINT { get; } = new();
         public Dictionary<ItemName, Item> ITEM_NAME_TO_ITEM { get; } = new();
@@ -73,14 +56,33 @@ namespace TrackOMatic
             HintData.Init();
             InitOptions();
             InitData();
+            ProgressiveKongSource =
+            [
+                (BitmapImage)FindResource("unknown_kong_bw"),
+                (BitmapImage)FindResource("donkey"),
+                (BitmapImage)FindResource("diddy"),
+                (BitmapImage)FindResource("lanky"),
+                (BitmapImage)FindResource("tiny"),
+                (BitmapImage)FindResource("chunky"),
+            ];
             foreach (var progressiveItem in HelmKongs!)
             {
-                progressiveItem.ImageSources = new() { ProgressiveKongSource };
+                progressiveItem.ImageSources = [ProgressiveKongSource];
             }
-            List<List<BitmapImage>> AllBosses = new() { ProgressiveKongSource, BossSource };
+            BossSource =
+            [
+                (BitmapImage)FindResource("army"),
+                (BitmapImage)FindResource("doga"),
+                (BitmapImage)FindResource("madjack"),
+                (BitmapImage)FindResource("pufftoss"),
+                (BitmapImage)FindResource("doga2"),
+                (BitmapImage)FindResource("army2"),
+                (BitmapImage)FindResource("kutout"),
+            ];
+            List<List<BitmapImage>> allBosses = [ProgressiveKongSource, BossSource];
             foreach (var progressiveItem in BossKongs!)
             {
-                progressiveItem.ImageSources = AllBosses;
+                progressiveItem.ImageSources = allBosses;
             }
 
             SpoilerParser = new(this);
@@ -533,19 +535,19 @@ namespace TrackOMatic
 
         public void UpdateProgHintImage(ItemType itemType)
         {
-            Dictionary<ItemType, string> itemTypeToImageString = new()
+            Dictionary<ItemType, string> itemTypeToResourceString = new()
             {
-                {ItemType.GOLDEN_BANANA, "Images/dk64/gb.png" },
-                {ItemType.TOTAL_BLUEPRINTS, "Images/dk64/total_bps.png" },
-                {ItemType.KEY, "Images/dk64/blankkey.png" },
-                {ItemType.BANANA_MEDAL, "Images/dk64/bananamedal.png" },
-                {ItemType.BATTLE_CROWN, "Images/dk64/crown.png" },
-                {ItemType.FAIRY,"Images/dk64/fairy.png" },
-                {ItemType.RAINBOW_COIN, "Images/dk64/rainbowcoin.png" },
-                {ItemType.PEARL, "Images/dk64/pearl.png" },
-                {ItemType.COLORED_BANANA, "Images/dk64/colored_bananas.png" }
+                {ItemType.GOLDEN_BANANA, "golden_banana" },
+                {ItemType.TOTAL_BLUEPRINTS, "total_bps" },
+                {ItemType.KEY, "basic_key" },
+                {ItemType.BANANA_MEDAL, "medal" },
+                {ItemType.BATTLE_CROWN, "crown" },
+                {ItemType.FAIRY,"fairy" },
+                {ItemType.RAINBOW_COIN, "rainbow_coin" },
+                {ItemType.PEARL, "pearl" },
+                {ItemType.COLORED_BANANA, "colored_bananas" }
             };
-            ItemsToNextHintImage.Source = new BitmapImage(new Uri(itemTypeToImageString[itemType], UriKind.Relative));
+            ItemsToNextHintImage.Source = (BitmapImage)FindResource(itemTypeToResourceString[itemType]);
         }
 
         public void UpdateUIAmountToNextHint(int newAmount)

--- a/TrackOMatic/RegionGrid.xaml.cs
+++ b/TrackOMatic/RegionGrid.xaml.cs
@@ -104,10 +104,10 @@ namespace TrackOMatic
 
         public void AddInitialVial(VialColor color)
         {
-            var imageName = (color.ToString() + "_vial.png").ToLower();
+            var resourceName = "vial_" + color.ToString().ToLowerInvariant();
             Item vialImage = new()
             {
-                ItemImage = new BitmapImage(new Uri("Images/dk64/" + imageName, UriKind.Relative))
+                ItemImage = (BitmapImage)FindResource(resourceName)
             };
             vialImage.SetRegion(Region);
             vialImage.Disable();


### PR DESCRIPTION
This ensures that each direct image call is handled in the same way within code behind files. This means using `FindResource` without having to worry about relative paths or subfolder depths.

Any additional keys that I felt needed to be added for consistenty were put in as well. It's entirely possible we don't need all of these images anymore, but I will advise we have a spearate discussion on that.

Any remaining hard-coded paths are switched from the backslash character to the forward slash character for future Linux compatibility.

The one area that was not touched was the `CollectibleItem`. This control will be addressed in a future pull request down the line. Much as I want to remove the hacky approach, I will not have time for a clean entry before my work trip.