### PR TITLE
Remove setting `DataContext = this` in all files.

### DIFF
--- a/TrackOMatic/BasicItemSelector.xaml.cs
+++ b/TrackOMatic/BasicItemSelector.xaml.cs
@@ -16,7 +16,6 @@ namespace TrackOMatic
             SelectedImageIndex = -1;
             images = new();
             InitializeComponent();
-            DataContext = this;
             for (int i = 0; i < toAdd.Count; ++i)
             {
                 var row = toAdd[i];

--- a/TrackOMatic/BroadcastView.xaml.cs
+++ b/TrackOMatic/BroadcastView.xaml.cs
@@ -138,7 +138,6 @@ namespace TrackOMatic
         public BroadcastView()
         {
             InitializeComponent();
-            DataContext = this;
             InitializeMap();
             Collectibles = new() {
                 { ItemType.DONKEY_BLUEPRINT, DonkeyBPs},

--- a/TrackOMatic/CollectibleItem.xaml
+++ b/TrackOMatic/CollectibleItem.xaml
@@ -1,23 +1,24 @@
-﻿<UserControl x:Class="TrackOMatic.CollectibleItem"
+<UserControl x:Class="TrackOMatic.CollectibleItem"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:TrackOMatic"
              MouseLeftButtonDown="Image_MouseLeftButtonDown"
              MouseRightButtonDown="Image_MouseRightButtonDown">
     <Grid >
         <Grid.RowDefinitions>
             <RowDefinition Height="1*"/>
-            <RowDefinition Height="{Binding RowHeight}"/>
+            <RowDefinition Height="{Binding RowHeight, RelativeSource={RelativeSource AncestorType=local:CollectibleItem}}"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
             <ColumnDefinition Width="1*"/>
         </Grid.ColumnDefinitions>
         <Viewbox Name="CountViewbox" Grid.Row="1" Grid.Column="9" Visibility="Hidden" Panel.ZIndex="2">
-            <Grid Background="{Binding BGColor}">
-                <TextBlock Margin="3,-1,2,0" x:Name="count" Text="{Binding Text}" Foreground="#FFFFFF" FontFamily="{DynamicResource DK64Font}" />
+            <Grid Background="{Binding BGColor, RelativeSource={RelativeSource AncestorType=local:CollectibleItem}}">
+                <TextBlock Margin="3,-1,2,0" x:Name="count" Text="{Binding Text, RelativeSource={RelativeSource AncestorType=local:CollectibleItem}}" Foreground="#FFFFFF" FontFamily="{DynamicResource DK64Font}" />
             </Grid>
         </Viewbox>
-        <Image Source="{Binding ImageSource}" x:Name="image" Margin="2" Grid.Row="0" Grid.RowSpan="2" Grid.ColumnSpan="2"
+        <Image Source="{Binding ImageSource, RelativeSource={RelativeSource AncestorType=local:CollectibleItem}}" x:Name="image" Margin="2" Grid.Row="0" Grid.RowSpan="2" Grid.ColumnSpan="2"
                 RenderOptions.ClearTypeHint="Enabled" HorizontalAlignment="Left">
             <Image.Effect>
                 <DropShadowEffect Color="Black" Direction="0" ShadowDepth="0" BlurRadius="14" Opacity="0.5" />

--- a/TrackOMatic/CollectibleItem.xaml.cs
+++ b/TrackOMatic/CollectibleItem.xaml.cs
@@ -138,7 +138,6 @@ namespace TrackOMatic
         public CollectibleItem()
         {
             InitializeComponent();
-            DataContext = this;
         }
 
         private void Image_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/TrackOMatic/HintsUI/BLockerHint.xaml.cs
+++ b/TrackOMatic/HintsUI/BLockerHint.xaml.cs
@@ -36,7 +36,6 @@ namespace TrackOMatic
         public BLockerHint()
         {
             InitializeComponent();
-            DataContext = this;
             List<List<BitmapImage>> BLockerSources = new()
                 {
                     new() { GetBarrierItemImage(BarrierItems.GOLDEN_BANANA),

--- a/TrackOMatic/HintsUI/BLockerPanel.xaml
+++ b/TrackOMatic/HintsUI/BLockerPanel.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="TrackOMatic.BLockerPanel"
+<UserControl x:Class="TrackOMatic.BLockerPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -14,7 +14,15 @@
                     <RowDefinition Height="26"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <TextBlock Margin="10,0,0,0" Padding="0,0,0,2" FontSize="20" Foreground="White" Grid.Row="0"  FontFamily="{DynamicResource DK64Font}" Text="{Binding Heading}" VerticalAlignment="Center"/>
+                <TextBlock
+                    Margin="10,0,0,0"
+                    Padding="0,0,0,2"
+                    FontSize="20"
+                    Foreground="White"
+                    Grid.Row="0"
+                    FontFamily="{DynamicResource DK64Font}"
+                    Text="{Binding Heading, RelativeSource={RelativeSource AncestorType=local:BLockerPanel}}"
+                    VerticalAlignment="Center"/>
                 <Border CornerRadius="1" Grid.Row="1" Margin="0" BorderThickness="0" BorderBrush="Black" Background="{StaticResource RegionImageBG}">
                     <UniformGrid Name="MainGrid" Grid.Row="1" Columns="2">
                         <local:BLockerHint RegionName="JUNGLE_JAPES"/>
@@ -33,8 +41,8 @@
         <Border CornerRadius="2" BorderThickness="3">
             <Border.BorderBrush>
                 <LinearGradientBrush StartPoint="0,0" EndPoint="1,0" SpreadMethod="Repeat">
-                    <GradientStop Color="{Binding LineColor}" Offset="0"/>
-                    <GradientStop Color="{Binding LineColor}" Offset="0.007"/>
+                    <GradientStop Color="{Binding LineColor, RelativeSource={RelativeSource AncestorType=local:BLockerPanel}}" Offset="0"/>
+                    <GradientStop Color="{Binding LineColor, RelativeSource={RelativeSource AncestorType=local:BLockerPanel}}" Offset="0.007"/>
                     <GradientStop Color="Transparent" Offset="0.008"/>
                     <GradientStop Color="Transparent" Offset="1"/>
                 </LinearGradientBrush>

--- a/TrackOMatic/HintsUI/BLockerPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/BLockerPanel.xaml.cs
@@ -31,7 +31,6 @@ namespace TrackOMatic
         public BLockerPanel()
         {
             InitializeComponent();
-            DataContext = this;
             foreach (var child in MainGrid.Children)
             {
                 if (child is BLockerHint hint)

--- a/TrackOMatic/HintsUI/HelmDoorHint.xaml
+++ b/TrackOMatic/HintsUI/HelmDoorHint.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="TrackOMatic.HelmDoorHint"
+<UserControl x:Class="TrackOMatic.HelmDoorHint"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -14,7 +14,7 @@
             <ColumnDefinition Width=".15*"/>
             <ColumnDefinition Width="2.5*"/>
         </Grid.ColumnDefinitions>
-        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="Label" Text="{Binding LabelText}" FontSize="16" FontFamily="Helvetica" Foreground="White" Grid.Column="0"/>
+        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="Label" Text="{Binding LabelText, RelativeSource={RelativeSource AncestorType=local:HelmDoorHint}}" FontSize="16" FontFamily="Helvetica" Foreground="White" Grid.Column="0"/>
         <local:ProgressiveItem x:Name="DoorItem" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"  />
         <local:ItemCountBox  VerticalAlignment="Center" HorizontalAlignment="Stretch" ContextMenu="{x:Null}" Text="?" x:Name="ItemCount" Grid.Column="3" Style="{StaticResource BoldText}" FontSize="18"/>
     </Grid>

--- a/TrackOMatic/HintsUI/HelmDoorHint.xaml.cs
+++ b/TrackOMatic/HintsUI/HelmDoorHint.xaml.cs
@@ -16,7 +16,6 @@ namespace TrackOMatic
         public HelmDoorHint()
         {
             InitializeComponent();
-            DataContext = this;
             List<List<BitmapImage>> BLockerSources = new()
             {
                 new()

--- a/TrackOMatic/HintsUI/HelmDoorPanel.xaml
+++ b/TrackOMatic/HintsUI/HelmDoorPanel.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="TrackOMatic.HelmDoorPanel"
+<UserControl x:Class="TrackOMatic.HelmDoorPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -14,7 +14,15 @@
                     <RowDefinition Height="26"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <TextBlock Margin="10,0,0,0" Padding="0,0,0,2" FontSize="20" Foreground="White" Grid.Row="0"  FontFamily="{DynamicResource DK64Font}" Text="{Binding Heading}" VerticalAlignment="Center"/>
+                <TextBlock
+                    Margin="10,0,0,0"
+                    Padding="0,0,0,2"
+                    FontSize="20"
+                    Foreground="White"
+                    Grid.Row="0"
+                    FontFamily="{DynamicResource DK64Font}"
+                    Text="{Binding Heading, RelativeSource={RelativeSource AncestorType=local:HelmDoorPanel}}"
+                    VerticalAlignment="Center"/>
                 <Border CornerRadius="1" Grid.Row="1" Margin="0" BorderThickness="0" BorderBrush="Black" Background="{StaticResource RegionImageBG}">
                     <UniformGrid Name="MainGrid" Grid.Row="1" Columns="2">
                         <local:HelmDoorHint LabelText="Door 1:"/>
@@ -26,8 +34,8 @@
         <Border CornerRadius="2" BorderThickness="3">
             <Border.BorderBrush>
                 <LinearGradientBrush StartPoint="0,0" EndPoint="1,0" SpreadMethod="Repeat">
-                    <GradientStop Color="{Binding LineColor}" Offset="0"/>
-                    <GradientStop Color="{Binding LineColor}" Offset="0.007"/>
+                    <GradientStop Color="{Binding LineColor, RelativeSource={RelativeSource AncestorType=local:HelmDoorPanel}}" Offset="0"/>
+                    <GradientStop Color="{Binding LineColor, RelativeSource={RelativeSource AncestorType=local:HelmDoorPanel}}" Offset="0.007"/>
                     <GradientStop Color="Transparent" Offset="0.008"/>
                     <GradientStop Color="Transparent" Offset="1"/>
                 </LinearGradientBrush>

--- a/TrackOMatic/HintsUI/HelmDoorPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/HelmDoorPanel.xaml.cs
@@ -31,7 +31,6 @@ namespace TrackOMatic
         public HelmDoorPanel()
         {
             InitializeComponent();
-            DataContext = this;
             hints = new();
             foreach (var child in MainGrid.Children)
             {

--- a/TrackOMatic/HintsUI/HintInfo.xaml
+++ b/TrackOMatic/HintsUI/HintInfo.xaml
@@ -21,7 +21,7 @@
                         <Style TargetType="RowDefinition">
                             <Setter Property="Height" Value="*"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="false">
+                                <DataTrigger Binding="{Binding Path=HintTypeSettings.PathItemsVisible, RelativeSource={RelativeSource AncestorType=local:HintInfo}}" Value="false">
                                     <Setter Property="Height" Value="0" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -32,10 +32,10 @@
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="false">
+                        <DataTrigger Binding="{Binding Path=HintTypeSettings.PathItemsVisible, RelativeSource={RelativeSource AncestorType=local:HintInfo}}" Value="false">
                             <Setter Property="Height" Value="23"/>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}" Value="true">
+                        <DataTrigger Binding="{Binding Path=HintTypeSettings.PathItemsVisible, RelativeSource={RelativeSource AncestorType=local:HintInfo}}" Value="true">
                             <Setter Property="Height" Value="46"/>
                         </DataTrigger>
                     </Style.Triggers>

--- a/TrackOMatic/HintsUI/HintInfo.xaml.cs
+++ b/TrackOMatic/HintsUI/HintInfo.xaml.cs
@@ -43,7 +43,6 @@ namespace TrackOMatic
         public HintInfo(HintType hintType, string panelName, bool isSavedHint = false, RegionName regionName = RegionName.UNKNOWN)
         {
             InitializeComponent();
-            DataContext = this;
             if (!isSavedHint)
             {
                 Location.Loaded += (sender, e) => Location.Focus();

--- a/TrackOMatic/HintsUI/HintItemList.xaml
+++ b/TrackOMatic/HintsUI/HintItemList.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="TrackOMatic.HintItemList"
+<UserControl x:Class="TrackOMatic.HintItemList"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -9,13 +9,13 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition />
-            <RowDefinition Name="BottomRow" Height="{Binding BottomRowHeight}"/>
+            <RowDefinition Name="BottomRow" Height="{Binding BottomRowHeight, RelativeSource={RelativeSource AncestorType=local:HintItemList}}"/>
         </Grid.RowDefinitions>
         <UniformGrid Grid.Row="0" Rows="1"
-            x:Name="ItemPanel" HorizontalAlignment="{Binding CustomHorizontalAlignment}" Background="{StaticResource RegionBG}">
+            x:Name="ItemPanel" HorizontalAlignment="{Binding CustomHorizontalAlignment, RelativeSource={RelativeSource AncestorType=local:HintItemList}}" Background="{StaticResource RegionBG}">
         </UniformGrid>
         <UniformGrid Grid.Row="1" Rows="1"
-            x:Name="ItemPanel2" HorizontalAlignment="{Binding CustomHorizontalAlignment}" Background="{StaticResource RegionBG}">
+            x:Name="ItemPanel2" HorizontalAlignment="{Binding CustomHorizontalAlignment, RelativeSource={RelativeSource AncestorType=local:HintItemList}}" Background="{StaticResource RegionBG}">
         </UniformGrid>
     </Grid>
 </UserControl>

--- a/TrackOMatic/HintsUI/HintItemList.xaml.cs
+++ b/TrackOMatic/HintsUI/HintItemList.xaml.cs
@@ -45,7 +45,6 @@ namespace TrackOMatic
         public HintItemList()
         {
             InitializeComponent();
-            DataContext = this;
             ProcessSelectedItems();
 
         }

--- a/TrackOMatic/HintsUI/HintItemSelectionDialog.xaml.cs
+++ b/TrackOMatic/HintsUI/HintItemSelectionDialog.xaml.cs
@@ -12,7 +12,6 @@ namespace TrackOMatic
         public HintItemSelectionDialog(List<ItemName> itemsToTurnOn)
         {
             InitializeComponent();
-            DataContext = this;
             foreach (var child in ItemGrid.Children)
             {
                 if (child is SelectableHintItem hintItem)

--- a/TrackOMatic/HintsUI/HintPanel.xaml
+++ b/TrackOMatic/HintsUI/HintPanel.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="TrackOMatic.HintPanel"
+<UserControl x:Class="TrackOMatic.HintPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -21,7 +21,7 @@
                         <ColumnDefinition Width="1*"/>
                         <ColumnDefinition Width=".1*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Margin="10,0,0,0" FontSize="18" Foreground="White" FontFamily="{DynamicResource DK64Font}" Text="{Binding Heading}" VerticalAlignment="Center" Padding="0,0,0,2"/>
+                    <TextBlock Grid.Column="0" Margin="10,0,0,0" FontSize="18" Foreground="White" FontFamily="{DynamicResource DK64Font}" Text="{Binding Heading, RelativeSource={RelativeSource AncestorType=local:HintPanel}}" VerticalAlignment="Center" Padding="0,0,0,2"/>
                     <Image Name="FilterButton" Grid.Column="1" Source="../Images/dk64/filter_empty.png" HorizontalAlignment="Center" Margin="2,2,2,3" MouseDown="FilterButton_MouseDown" Cursor="Hand" Visibility="Hidden"/>
                     <Image Name="SortButton" Grid.Column="2" Source="../Images/dk64/sort.png" HorizontalAlignment="Center" Margin="2,2,2,3" MouseDown="SortButton_MouseDown" Cursor="Hand" Visibility="Hidden"/>
                 </Grid>
@@ -42,8 +42,8 @@
         <Border CornerRadius="2" BorderThickness="3">
             <Border.BorderBrush>
                 <LinearGradientBrush StartPoint="0,0" EndPoint="1,0" SpreadMethod="Repeat">
-                    <GradientStop Color="{Binding LineColor}" Offset="0"/>
-                    <GradientStop Color="{Binding LineColor}" Offset="0.007"/>
+                    <GradientStop Color="{Binding LineColor, RelativeSource={RelativeSource AncestorType=local:HintPanel}}" Offset="0"/>
+                    <GradientStop Color="{Binding LineColor, RelativeSource={RelativeSource AncestorType=local:HintPanel}}" Offset="0.007"/>
                     <GradientStop Color="Transparent" Offset="0.008"/>
                     <GradientStop Color="Transparent" Offset="1"/>
                 </LinearGradientBrush>

--- a/TrackOMatic/HintsUI/HintPanel.xaml.cs
+++ b/TrackOMatic/HintsUI/HintPanel.xaml.cs
@@ -53,7 +53,6 @@ namespace TrackOMatic
         {
             Console.WriteLine(HintType);
             InitializeComponent();
-            DataContext = this;
             Loaded += OnLoaded;
         }
 

--- a/TrackOMatic/HintsUI/PathOrFoundItem.xaml
+++ b/TrackOMatic/HintsUI/PathOrFoundItem.xaml
@@ -1,4 +1,4 @@
-﻿<ContentControl x:Class="TrackOMatic.PathOrFoundItem"
+<ContentControl x:Class="TrackOMatic.PathOrFoundItem"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -16,7 +16,7 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Direction="0" ShadowDepth="0" BlurRadius="14" Opacity="0.5" />
                 </Border.Effect>
-                <Image x:Name="image" Source="{Binding PathItemImage}"/>
+                <Image x:Name="image" Source="{Binding PathItemImage, RelativeSource={RelativeSource AncestorType=local:PathOrFoundItem}}"/>
             </Border>
             <Image x:Name="Checkmark" Source="../images/dk64/checkmark.png" Visibility="Hidden"/>
         </Grid>

--- a/TrackOMatic/HintsUI/PathOrFoundItem.xaml.cs
+++ b/TrackOMatic/HintsUI/PathOrFoundItem.xaml.cs
@@ -30,7 +30,6 @@ namespace TrackOMatic
         {
             InitializeComponent();
             SetResourceReference(PathItemImageProperty, itemName.ToString().ToLower());
-            DataContext = this;
             IsChecked = isChecked;
             ItemName = itemName;
             HintItemList = hintItemList;

--- a/TrackOMatic/HintsUI/SelectableHintItem.xaml
+++ b/TrackOMatic/HintsUI/SelectableHintItem.xaml
@@ -1,4 +1,4 @@
-﻿<ContentControl x:Class="TrackOMatic.SelectableHintItem"
+<ContentControl x:Class="TrackOMatic.SelectableHintItem"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -18,7 +18,7 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Direction="0" ShadowDepth="0" BlurRadius="14" Opacity="0.5" />
                 </Border.Effect>
-                <Image x:Name="Image" Source="{Binding HintItemImage}"/>
+                <Image x:Name="Image" Source="{Binding HintItemImage, RelativeSource={RelativeSource AncestorType=local:SelectableHintItem}}"/>
             </Border>
         </Grid>
     </ContentControl.Content>

--- a/TrackOMatic/HintsUI/SelectableHintItem.xaml.cs
+++ b/TrackOMatic/HintsUI/SelectableHintItem.xaml.cs
@@ -30,7 +30,6 @@ namespace TrackOMatic
         public SelectableHintItem()
         {
             InitializeComponent();
-            DataContext = this;
         }
 
         public void UpdateImageFromState()

--- a/TrackOMatic/Item.xaml
+++ b/TrackOMatic/Item.xaml
@@ -1,4 +1,4 @@
-﻿<ContentControl x:Class="TrackOMatic.Item" Loaded="Item_OnLoaded"
+<ContentControl x:Class="TrackOMatic.Item" Loaded="Item_OnLoaded"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -27,13 +27,13 @@
                     RenderOptions.ClearTypeHint="Enabled"
                                   ToolTipService.InitialShowDelay="500" ToolTipService.HasDropShadow="True">
                 <Border.ToolTip>
-                    <ToolTip Name="ToolTip" Content="{Binding HoverText}" Placement="Mouse" Visibility="Collapsed">
+                    <ToolTip Name="ToolTip" Content="{Binding HoverText, RelativeSource={RelativeSource AncestorType=local:Item}}" Placement="Mouse" Visibility="Collapsed">
                     </ToolTip>
                 </Border.ToolTip>
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Direction="0" ShadowDepth="0" BlurRadius="14" Opacity="0.5" />
                 </Border.Effect>
-                <Image x:Name="Image" Source="{Binding ItemImage}"/>
+                <Image x:Name="Image" Source="{Binding ItemImage, RelativeSource={RelativeSource AncestorType=local:Item}}"/>
             </Border>
             <Image x:Name="Star" Source="{StaticResource star_complex}" Visibility="Hidden" HorizontalAlignment="Left" IsHitTestVisible="False" Margin="0,0,4,4"/>
         </Grid>

--- a/TrackOMatic/Item.xaml.cs
+++ b/TrackOMatic/Item.xaml.cs
@@ -106,7 +106,6 @@ namespace TrackOMatic
 
         public Item()
         {
-            DataContext = this;
             InitializeComponent();
         }
 

--- a/TrackOMatic/ItemBackground.xaml
+++ b/TrackOMatic/ItemBackground.xaml
@@ -1,4 +1,4 @@
-﻿<ContentControl x:Class="TrackOMatic.ItemBackground" Loaded="OnLoaded"
+<ContentControl x:Class="TrackOMatic.ItemBackground" Loaded="OnLoaded"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -31,7 +31,7 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Direction="0" ShadowDepth="0" BlurRadius="14" Opacity="0.5" />
                 </Border.Effect>
-                <Image x:Name="Image" Source="{Binding BackgroundItemImage}"/>
+                <Image x:Name="Image" Source="{Binding BackgroundItemImage, RelativeSource={RelativeSource AncestorType=local:ItemBackground}}"/>
             </Border>
             <Image Margin="0,0,4,4" x:Name="Star" Source="{StaticResource star_complex}" Visibility="Hidden" HorizontalAlignment="Left" IsHitTestVisible="False"/>
         </Grid>

--- a/TrackOMatic/ItemBackground.xaml.cs
+++ b/TrackOMatic/ItemBackground.xaml.cs
@@ -32,7 +32,6 @@ namespace TrackOMatic
         public ItemBackground()
         {
             InitializeComponent();
-            DataContext = this;
         }
 
         public void ChangeOpacity(double newOpacity)

--- a/TrackOMatic/LevelOrderNumber.xaml.cs
+++ b/TrackOMatic/LevelOrderNumber.xaml.cs
@@ -16,7 +16,6 @@ namespace TrackOMatic
         public LevelOrderNumber()
         {
             InitializeComponent();
-            DataContext = this;
             currentNumber = 0;
         }
 

--- a/TrackOMatic/ProgHintDialog.xaml
+++ b/TrackOMatic/ProgHintDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="TrackOMatic.ProgHintDialog" Closed="Window_Closed"
+<Window x:Class="TrackOMatic.ProgHintDialog" Closed="Window_Closed"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -21,7 +21,7 @@
             <ColumnDefinition Width="0*" />
         </Grid.ColumnDefinitions>
         <ComboBox Margin="6" Padding="6,5,0,0" Name="itemDropdown" Grid.Row="1" Grid.Column="0"
-                  SelectedItem="{Binding SelectedItemType, Mode=TwoWay}"
+                  SelectedItem="{Binding SelectedItemType, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=local:ProgHintDialog}}"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="stretch"
                   FontSize="14" FontFamily="Helvetica"/>

--- a/TrackOMatic/ProgHintDialog.xaml.cs
+++ b/TrackOMatic/ProgHintDialog.xaml.cs
@@ -38,7 +38,6 @@ namespace TrackOMatic
         public ProgHintDialog()
         {
             InitializeComponent();
-            DataContext = this;
             var itemType = (ItemType)Properties.Settings.Default.ProgressiveHintItem;
             SelectedItemType = ItemTypeToPlural[itemType];
             var itemTypes = new ItemType[] { ItemType.GOLDEN_BANANA, ItemType.TOTAL_BLUEPRINTS, ItemType.KEY, ItemType.BANANA_MEDAL, ItemType.BATTLE_CROWN, ItemType.FAIRY, ItemType.RAINBOW_COIN, ItemType.PEARL, ItemType.COLORED_BANANA };

--- a/TrackOMatic/ProgressiveItem.xaml.cs
+++ b/TrackOMatic/ProgressiveItem.xaml.cs
@@ -36,7 +36,6 @@ namespace TrackOMatic
         public ProgressiveItem()
         {
             InitializeComponent();
-            DataContext = this;
             ImageSources = new List<List<BitmapImage>>();
         }
 


### PR DESCRIPTION
Technically setting `DataContext = this` is an anti-pattern that can break inheritance chains and make future OS support trickier. All instances of bindings have been replaced with the use of `RelativeSource={RelativeSource AncestorType=local:<type>}` for compatibility. Bit of a mouthful admittedly, but at least we are (to my knowledge) always guaranteed to have the element in question.