### PR TITLE
Store scouring potion count if you unfocus without pressing enter

### DIFF
--- a/TrackOMatic/HintsUI/HintInfo.xaml
+++ b/TrackOMatic/HintsUI/HintInfo.xaml
@@ -41,7 +41,7 @@
                 <ColumnDefinition Width="2*"/>
             </Grid.ColumnDefinitions>
             <TextBox ContextMenu="{x:Null}" Margin="1,0,0,0" TextChanged="Location_TextChanged" PreviewMouseRightButtonDown="Location_PreviewMouseRightButtonDown"  PreviewKeyDown="Location_PreviewKeyDown" x:Name="Location" Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource BoldText}"/>
-            <TextBox ContextMenu="{x:Null}" x:Name="PotionCount" PreviewMouseRightButtonDown="Location_PreviewMouseRightButtonDown"  PreviewKeyDown="PotionCount_PreviewKeyDown" Margin="0,0,3,0"  Grid.Column="1" HorizontalContentAlignment="Right" Style="{StaticResource BoldText}" VerticalAlignment="Center" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PotionCountVisibility}"/>
+            <TextBox ContextMenu="{x:Null}" x:Name="PotionCount" TextChanged="PotionCount_TextChanged" PreviewMouseRightButtonDown="Location_PreviewMouseRightButtonDown"  PreviewKeyDown="PotionCount_PreviewKeyDown" Margin="0,0,3,0"  Grid.Column="1" HorizontalContentAlignment="Right" Style="{StaticResource BoldText}" VerticalAlignment="Center" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PotionCountVisibility}"/>
 
             <local:HintItemList Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" x:Name="RightItems" BottomRowHeight="*" CustomHorizontalAlignment="Right" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.FoundItemVisible}"/>
             <local:HintItemList Margin="1,0,0,0" Loaded="HintInfoWindow_Loaded" x:Name="ItemsOnPath" Grid.Row="1" BottomRowHeight="0" CustomHorizontalAlignment="Left" Visibility="{Binding ElementName=HintInfoWindow, Path=HintTypeSettings.PathItemsVisible}"/>

--- a/TrackOMatic/HintsUI/HintInfo.xaml.cs
+++ b/TrackOMatic/HintsUI/HintInfo.xaml.cs
@@ -267,6 +267,12 @@ namespace TrackOMatic
                 ), System.Windows.Threading.DispatcherPriority.ContextIdle, null);
             }
         }
+
+        private void PotionCount_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            SavedHint.PotionCountText = PotionCount.Text;
+        }
+
         private void PotionCount_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Enter)


### PR DESCRIPTION
Fix bug: If you type in the potion count for a scouring hint, but unfocus by means other than pressing enter, the value is not stored and will be lost when saving.