### PR TITLE
Simple service: Portable Version Data.

### DIFF
--- a/Directory.props
+++ b/Directory.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Shared version property for all projects -->
+  <PropertyGroup>
+    <Version>2.1.8</Version>
+  </PropertyGroup>
+</Project>

--- a/TrackOMatic.Logic.Test/TrackOMatic.Logic.Test.csproj
+++ b/TrackOMatic.Logic.Test/TrackOMatic.Logic.Test.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Directory.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/TrackOMatic.Logic/TrackOMatic.Logic.csproj
+++ b/TrackOMatic.Logic/TrackOMatic.Logic.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Directory.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/TrackOMatic.Services.Test/TrackOMatic.Services.Test.csproj
+++ b/TrackOMatic.Services.Test/TrackOMatic.Services.Test.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Directory.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/TrackOMatic.Services.Test/VersionServiceTests.cs
+++ b/TrackOMatic.Services.Test/VersionServiceTests.cs
@@ -1,0 +1,120 @@
+namespace TrackOMatic.Services.Test;
+
+public class VersionServiceTests
+{
+    private readonly VersionService _sut = new();
+
+    [Fact]
+    public void GetApplicationVersion_ReturnsValidVersion()
+    {
+        // Arrange & Act
+        var version = _sut.GetApplicationVersion();
+
+        Assert.Multiple(() =>
+        {
+            // Assert
+            Assert.NotNull(version);
+            Assert.True(version.Major >= 0, "Major version should be non-negative");
+        });
+    }
+
+    [Fact]
+    public void GetApplicationVersion_ComponentsAreNonNegative()
+    {
+        // Arrange & Act
+        var version = _sut.GetApplicationVersion();
+
+        Assert.Multiple(() =>
+        {
+            // Assert
+            Assert.True(version.Major >= 0, "Major version should be non-negative");
+            Assert.True(version.Minor >= 0, "Minor version should be non-negative");
+            Assert.True(version.Build >= 0, "Build version should be non-negative");
+            Assert.True(version.Revision >= 0, "Revision should be non-negative");
+        });
+    }
+
+    [Fact]
+    public void GetVersionString_ReturnsFormattedString()
+    {
+        // Arrange & Act
+        var versionString = _sut.GetVersionString();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.NotNull(versionString);
+            Assert.NotEmpty(versionString);
+            Assert.Matches(@"^\d+\.\d+\.\d+$", versionString); // Matches Major.Minor.Build format
+        });
+    }
+
+    [Fact]
+    public void GetVersionString_FormatsAsExpected()
+    {
+        // Arrange & Act
+        var version = _sut.GetApplicationVersion();
+        var versionString = _sut.GetVersionString();
+        var expectedFormat = $"{version.Major}.{version.Minor}.{version.Build}";
+
+        // Assert
+        Assert.Equal(expectedFormat, versionString);
+    }
+
+    [Fact]
+    public void GetVersionString_DoesNotIncludeRevision()
+    {
+        // Arrange & Act
+        var version = _sut.GetApplicationVersion();
+        var versionString = _sut.GetVersionString();
+
+        // Assert
+        // Should have exactly 2 dots for Major.Minor.Build format
+        var dotCount = versionString.Count(c => c == '.');
+        Assert.Equal(2, dotCount);
+    }
+
+    [Fact]
+    public void GetApplicationVersion_ConsistentBetweenCalls()
+    {
+        // Arrange & Act
+        var version1 = _sut.GetApplicationVersion();
+        var version2 = _sut.GetApplicationVersion();
+
+        // Assert
+        Assert.Equal(version1, version2);
+    }
+
+    [Fact]
+    public void GetVersionString_ConsistentBetweenCalls()
+    {
+        // Arrange & Act
+        var versionString1 = _sut.GetVersionString();
+        var versionString2 = _sut.GetVersionString();
+
+        // Assert
+        Assert.Equal(versionString1, versionString2);
+    }
+
+    [Fact]
+    public void GetVersionString_VersionStringAndApplicationVersionAreConsistent()
+    {
+        // Arrange & Act
+        var appVersion = _sut.GetApplicationVersion();
+        var versionString = _sut.GetVersionString();
+
+        // Parse the version string to verify it matches the application version
+        var parts = versionString.Split('.');
+        var parsedMajor = int.Parse(parts[0]);
+        var parsedMinor = int.Parse(parts[1]);
+        var parsedBuild = int.Parse(parts[2]);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.Equal(appVersion.Major, parsedMajor);
+            Assert.Equal(appVersion.Minor, parsedMinor);
+            Assert.Equal(appVersion.Build, parsedBuild);
+        });
+    }
+}

--- a/TrackOMatic.Services/IVersionService.cs
+++ b/TrackOMatic.Services/IVersionService.cs
@@ -1,0 +1,8 @@
+namespace TrackOMatic.Services;
+
+public interface IVersionService
+{
+    public Version GetApplicationVersion();
+
+    public string GetVersionString();
+}

--- a/TrackOMatic.Services/ServiceLocator.cs
+++ b/TrackOMatic.Services/ServiceLocator.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TrackOMatic.Services;
+
+public static class ServiceLocator
+{
+    private static IServiceProvider? _provider;
+
+    public static void Initialize(IServiceProvider provider) => _provider = provider;
+
+    public static T GetService<T>() where T : notnull
+    {
+        if (_provider == null)
+        {
+            throw new InvalidOperationException("ServiceLocator not initialized");
+        }
+
+        return _provider.GetRequiredService<T>();
+    }
+}

--- a/TrackOMatic.Services/TrackOMatic.Services.csproj
+++ b/TrackOMatic.Services/TrackOMatic.Services.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Directory.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/TrackOMatic.Services/VersionService.cs
+++ b/TrackOMatic.Services/VersionService.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace TrackOMatic.Services;
+
+public class VersionService : IVersionService
+{
+    public Version GetApplicationVersion()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        return version ?? new(0, 0, 0, 0);
+    }
+
+    public string GetVersionString()
+    {
+        var version = GetApplicationVersion();
+        return $"{version.Major}.{version.Minor}.{version.Build}";
+    }
+}

--- a/TrackOMatic.ViewModels.Test/TrackOMatic.ViewModels.Test.csproj
+++ b/TrackOMatic.ViewModels.Test/TrackOMatic.ViewModels.Test.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Directory.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/TrackOMatic.ViewModels/TrackOMatic.ViewModels.csproj
+++ b/TrackOMatic.ViewModels/TrackOMatic.ViewModels.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Directory.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/TrackOMatic/App.xaml
+++ b/TrackOMatic/App.xaml
@@ -1,9 +1,8 @@
-﻿<Application x:Class="TrackOMatic.App"
+<Application x:Class="TrackOMatic.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:TrackOMatic"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             StartupUri="MainWindow.xaml"
              Exit="App_Exit">
     <Application.Resources>
         <ResourceDictionary>

--- a/TrackOMatic/App.xaml.cs
+++ b/TrackOMatic/App.xaml.cs
@@ -1,52 +1,60 @@
-using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
+
+using Microsoft.Extensions.DependencyInjection;
+
 using TrackOMatic.Properties;
+using TrackOMatic.Services;
 
-namespace TrackOMatic
+namespace TrackOMatic;
+
+/// <summary>
+/// Interaction logic for App.xaml
+/// </summary>
+public partial class App : Application
 {
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
-    public partial class App : Application
+    private readonly IServiceProvider _serviceProvider;
+
+    App()
     {
+        var services = new ServiceCollection();
+        services.AddSingleton<IVersionService, VersionService>();
 
-        App()
-        {
-            Dispatcher.UnhandledException += OnDispatcherUnhandledException;
-        }
+        _serviceProvider = services.BuildServiceProvider();
+        ServiceLocator.Initialize(_serviceProvider);
+        Dispatcher.UnhandledException += OnDispatcherUnhandledException;
+    }
 
-        private void App_Exit(object sender, ExitEventArgs e)
-        {
-        }
+    private void App_Exit(object sender, ExitEventArgs e)
+    {
+    }
 
-        void OnDispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
-        {
-        }
+    void OnDispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+    {
+    }
 
-        protected override void OnStartup(StartupEventArgs e)
-        {
-            base.OnStartup(e);
-            UpdatePadBarrelImages();
-        }
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
 
-        public void UpdatePadBarrelImages()
+        var versionService = _serviceProvider.GetRequiredService<IVersionService>();
+        MainWindow mainWindow = new(versionService);
+        mainWindow.Show();
+
+        UpdatePadBarrelImages();
+    }
+
+    public void UpdatePadBarrelImages()
+    {
+        var dicts = Resources.MergedDictionaries;
+        dicts.Clear();
+        dicts.Add(new ResourceDictionary
         {
-            var dicts = Resources.MergedDictionaries;
-            dicts.Clear();
-            dicts.Add(new ResourceDictionary
-            {
-                Source = new Uri("Dictionary1.xaml", UriKind.Relative)
-            });
-            var path = Settings.Default.ColoredBarrelPadMoves ? "ColoredBarrelPadImages.xaml" : "BaseBarrelPadImages.xaml";
-            dicts.Add(new ResourceDictionary
-            {
-                Source = new Uri(path, UriKind.Relative)
-            });
-        }
+            Source = new Uri("Dictionary1.xaml", UriKind.Relative)
+        });
+        var path = Settings.Default.ColoredBarrelPadMoves ? "ColoredBarrelPadImages.xaml" : "BaseBarrelPadImages.xaml";
+        dicts.Add(new ResourceDictionary
+        {
+            Source = new Uri(path, UriKind.Relative)
+        });
     }
 }

--- a/TrackOMatic/AutoUpdateInfo.xml
+++ b/TrackOMatic/AutoUpdateInfo.xml
@@ -5,3 +5,4 @@
   <changelog>https://github.com/Brian0255/Track-O-Matic/releases</changelog>
   <mandatory>false</mandatory>
 </item>
+

--- a/TrackOMatic/MainWindow.xaml
+++ b/TrackOMatic/MainWindow.xaml
@@ -76,7 +76,10 @@
                     <MenuItem Name="BroadcastSongDisplay" Header="Song Display" IsCheckable="True" StaysOpenOnClick="True" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=BroadcastSongDisplay}" Click="BroadcastSongDisplayToggle"/>
                 </MenuItem>
             </MenuItem>
-            <MenuItem Header="Version 2.1.8" IsHitTestVisible="False" Focusable="False" HorizontalAlignment="Right"/>
+            <MenuItem Header="{Binding ApplicationVersion, StringFormat='Version {0}'}"
+                      IsHitTestVisible="False"
+                      Focusable="False"
+                      HorizontalAlignment="Right"/>
         </Menu>
         <Grid>
             <Grid.ColumnDefinitions>

--- a/TrackOMatic/MainWindow.xaml.cs
+++ b/TrackOMatic/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using AutoUpdaterDotNET;
 using Microsoft.Win32;
 
 using TrackOMatic.Properties;
+using TrackOMatic.Services;
 
 using Timer = System.Timers.Timer;
 
@@ -19,7 +20,7 @@ namespace TrackOMatic
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    public partial class MainWindow : Window, INotifyPropertyChanged
     {
         public int TotalGBs { get; private set; }
         public BroadcastView? BroadcastView { get; private set; }
@@ -48,10 +49,36 @@ namespace TrackOMatic
         public Dictionary<ItemName, PathOrFoundItem> ITEM_TO_DIRECT_HINT { get; } = new();
         public Dictionary<ItemName, Item> ITEM_NAME_TO_ITEM { get; } = new();
 
+        public IVersionService VersionService { get; init; }
+
+        private string _applicationVersion = "";
+        public string ApplicationVersion
+        {
+            get => _applicationVersion;
+            private set
+            {
+                if (_applicationVersion != value)
+                {
+                    _applicationVersion = value;
+                    OnPropertyChanged(nameof(ApplicationVersion));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
         // Timer to save the data every minute. This is properly initialized, but the compiler is finicky.
         private Timer SaveTimer = null!;
-        public MainWindow()
+        public MainWindow(IVersionService versionService)
         {
+            VersionService = versionService;
+            ApplicationVersion = VersionService.GetVersionString();
+            DataContext = this;
             InitializeComponent();
             HintData.Init();
             InitOptions();
@@ -699,7 +726,7 @@ namespace TrackOMatic
             AutoUpdater.UpdateFormSize = new System.Drawing.Size(1300, 600);
             AutoUpdater.Icon = Properties.Resources.app.ToBitmap();
 
-            AutoUpdater.InstalledVersion = new Version("2.1.8");
+            AutoUpdater.InstalledVersion = VersionService.GetApplicationVersion();
 
             AutoUpdater.Start("https://raw.githubusercontent.com/Brian0255/Track-O-Matic/master/TrackOMatic/AutoUpdateInfo.xml");
             if (Settings.Default.DesiredHeight == 0 || Settings.Default.DesiredWidth == 0)

--- a/TrackOMatic/Scripts/UpdateAutoUpdateInfo.ps1
+++ b/TrackOMatic/Scripts/UpdateAutoUpdateInfo.ps1
@@ -1,0 +1,15 @@
+param(
+    [string]$Version = "2.1.8",
+    [string]$OutputPath = "AutoUpdateInfo.xml"
+)
+
+$xml = [xml](Get-Content $OutputPath)
+$xml.item.version = $Version
+$xml.item.url = "https://github.com/Brian0255/Track-O-Matic/releases/download/$Version/TrackOMatic_$Version.zip"
+$xml.Save($OutputPath)
+
+# Ensure file ends with a blank line
+Add-Content -Path $OutputPath -Value "" -NoNewline
+Add-Content -Path $OutputPath -Value ""
+
+Write-Host "Updated AutoUpdateInfo.xml to version $Version"

--- a/TrackOMatic/Scripts/UpdateAutoUpdateInfo.sh
+++ b/TrackOMatic/Scripts/UpdateAutoUpdateInfo.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Cross-platform script to update AutoUpdateInfo.xml with version information
+
+VERSION="${1:-2.1.8}"
+OUTPUT_PATH="${2:-AutoUpdateInfo.xml}"
+
+# Check if the output file exists
+if [ ! -f "$OUTPUT_PATH" ]; then
+	echo "Error: $OUTPUT_PATH not found"
+	exit 1
+fi
+
+# Use a temporary file to avoid issues with in-place editing
+TEMP_FILE="${OUTPUT_PATH}.tmp"
+
+# Update the version in the XML file
+# This approach handles the XML parsing in a cross-platform way
+sed "s|<version>.*</version>|<version>$VERSION</version>|g" "$OUTPUT_PATH" > "$TEMP_FILE"
+
+# Update the URL to include the version
+sed -i.bak "s|<url>.*</url>|<url>https://github.com/Brian0255/Track-O-Matic/releases/download/$VERSION/TrackOMatic_$VERSION.zip</url>|g" "$TEMP_FILE"
+
+# Remove the backup file created by sed -i
+rm -f "${TEMP_FILE}.bak"
+
+# Move the temp file to replace the original
+mv "$TEMP_FILE" "$OUTPUT_PATH"
+
+# Ensure file ends with a newline
+echo "" >> "$OUTPUT_PATH"
+
+echo "Updated AutoUpdateInfo.xml to version $VERSION"

--- a/TrackOMatic/Track-O-Matic.csproj
+++ b/TrackOMatic/Track-O-Matic.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../Directory.props" />
+
   <PropertyGroup>
     <!-- Target Framework -->
     <TargetFramework>net10.0-windows</TargetFramework>
@@ -86,5 +88,13 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
+
+  <!-- Version Sync Script - Cross-platform support -->
+  <Target Name="UpdateAutoUpdateInfo" AfterTargets="Build">
+    <!-- PowerShell on Windows -->
+    <Exec Command="powershell -ExecutionPolicy Bypass -File $(ProjectDir)Scripts\UpdateAutoUpdateInfo.ps1 -Version $(Version) -OutputPath $(ProjectDir)AutoUpdateInfo.xml" Condition="'$(OS)' == 'Windows_NT'" />
+    <!-- Bash on Linux/macOS -->
+    <Exec Command="bash $(ProjectDir)Scripts/UpdateAutoUpdateInfo.sh $(Version) $(ProjectDir)AutoUpdateInfo.xml" Condition="'$(OS)' != 'Windows_NT'" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
This allows the version to be set in one place to be reused throughout the code base and `AutoUpdateInfo.xml` file with no need to worry about manually modifying the version in multiple files. The parameters in the PowerShell/bash script are just defaulted to the current version.

Also, good way to introduce dependency injection & unit tests.